### PR TITLE
Adding a constructor to filter

### DIFF
--- a/src/Particle/Filter/Filter.php
+++ b/src/Particle/Filter/Filter.php
@@ -26,6 +26,13 @@ class Filter
     protected $globalChain = null;
 
     /**
+     * Construct the filter.
+     */
+    public function __construct()
+    {
+    }
+
+    /**
      * Set a filter for a value on a specific key
      *
      * @param string $key


### PR DESCRIPTION
## What?

Scrutinizer is raging about a PHP-4 style constructor, which is not actually a constructor. This PR is to make sure the `__construct` also exists, so hopefully it will not see it as an issue any more.
