### PR TITLE
Upper words filter

### DIFF
--- a/src/FilterResource.php
+++ b/src/FilterResource.php
@@ -183,6 +183,26 @@ class FilterResource
     }
 
     /**
+     * Add camel-case which is a combo of Lower + UpperWords
+     *
+     * @return $this
+     */
+    public function camelCase()
+    {
+        return $this->lower()->UpperWords();
+    }
+
+    /**
+     * Add upper-words filter-rule to the chain
+     *
+     * @return $this
+     */
+    public function upperWords()
+    {
+        return $this->addRule(new FilterRule\UpperWords());
+    }
+
+    /**
      * Add a new rule to the chain
      *
      * @param FilterRule $rule

--- a/src/FilterRule/UpperWords.php
+++ b/src/FilterRule/UpperWords.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Particle.
+ *
+ * @link      http://github.com/particle-php for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Particle (http://particle-php.com)
+ * @license   https://github.com/particle-php/Filter/blob/master/LICENSE New BSD License
+ */
+namespace Particle\Filter\FilterRule;
+
+use Particle\Filter\FilterRule;
+
+/**
+ * Class UpperFirst
+ *
+ * @package Particle\Filter\FilterRule
+ */
+class UpperWords extends FilterRule
+{
+    /**
+     * Uppercase the first character of the value
+     *
+     * @param mixed $value
+     * @return string
+     */
+    public function filter($value)
+    {
+        return ucwords($value);
+    }
+}

--- a/tests/FilterRule/CamelCaseTest.php
+++ b/tests/FilterRule/CamelCaseTest.php
@@ -1,0 +1,63 @@
+<?php
+namespace Particle\Tests\Filter\FilterRule;
+
+use Particle\Filter\Filter;
+
+class CamelCaseTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Filter
+     */
+    protected $filter;
+
+    /**
+     * Prepare the filter
+     */
+    public function setUp()
+    {
+        $this->filter = new Filter();
+    }
+
+    /**
+     * @dataProvider getCamelCaseResults
+     * @param string $value
+     * @param string $filteredValue
+     */
+    public function testCamelCaseFilterRule($value, $filteredValue)
+    {
+        $this->filter->value('test')->camelCase();
+
+        $result = $this->filter->filter([
+            'test' => $value
+        ]);
+
+        $this->assertEquals($result['test'], $filteredValue);
+    }
+
+    /**
+     * @return array
+     */
+    public function getCamelCaseResults()
+    {
+//        return [
+//            ['text is low', 'Text Is Low'],
+//            ['foo bar', 'Foo Bar'],
+//            ['fOo bAr', 'FOo BAr'],
+//            ['FOO BAR', 'FOO BAR'],
+//            ['', ''],
+//            ['lol', 'Lol'],
+//            ['l0l', 'L0l'],
+//            ['~!lolz!~', '~!lolz!~'],
+//        ];
+        return [
+            ['text is low', 'Text Is Low'],
+            ['foo bar', 'Foo Bar'],
+            ['fOo bAr', 'Foo Bar'],
+            ['FOO BAR', 'Foo Bar'],
+            ['', ''],
+            ['lol', 'Lol'],
+            ['l0l', 'L0l'],
+            ['~!lolz!~', '~!lolz!~'],
+        ];
+    }
+}

--- a/tests/FilterRule/CamelCaseTest.php
+++ b/tests/FilterRule/CamelCaseTest.php
@@ -39,16 +39,6 @@ class CamelCaseTest extends \PHPUnit_Framework_TestCase
      */
     public function getCamelCaseResults()
     {
-//        return [
-//            ['text is low', 'Text Is Low'],
-//            ['foo bar', 'Foo Bar'],
-//            ['fOo bAr', 'FOo BAr'],
-//            ['FOO BAR', 'FOO BAR'],
-//            ['', ''],
-//            ['lol', 'Lol'],
-//            ['l0l', 'L0l'],
-//            ['~!lolz!~', '~!lolz!~'],
-//        ];
         return [
             ['text is low', 'Text Is Low'],
             ['foo bar', 'Foo Bar'],

--- a/tests/FilterRule/UpperWordsTest.php
+++ b/tests/FilterRule/UpperWordsTest.php
@@ -1,0 +1,53 @@
+<?php
+namespace Particle\Tests\Filter\FilterRule;
+
+use Particle\Filter\Filter;
+
+class UpperWordsTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Filter
+     */
+    protected $filter;
+
+    /**
+     * Prepare the filter
+     */
+    public function setUp()
+    {
+        $this->filter = new Filter();
+    }
+
+    /**
+     * @dataProvider getUpperWordsResults
+     * @param string $value
+     * @param string $filteredValue
+     */
+    public function testUpperWordsFilterRule($value, $filteredValue)
+    {
+        $this->filter->value('test')->upperWords();
+
+        $result = $this->filter->filter([
+            'test' => $value
+        ]);
+
+        $this->assertEquals($result['test'], $filteredValue);
+    }
+
+    /**
+     * @return array
+     */
+    public function getUpperWordsResults()
+    {
+        return [
+            ['text is low', 'Text Is Low'],
+            ['foo bar', 'Foo Bar'],
+            ['fOo bAr', 'FOo BAr'],
+            ['FOO BAR', 'FOO BAR'],
+            ['', ''],
+            ['lol', 'Lol'],
+            ['l0l', 'L0l'],
+            ['~!lolz!~', '~!lolz!~'],
+        ];
+    }
+}


### PR DESCRIPTION
Hello,

I know that you removed the Camel case from the first release, but it's so simple that I decided to do it! :)
I did a Upper Words filter (ucwords) and then created the Camel Case filter by chaining lower and Upper Words. I don't know if the camel case strategy is desired by you, please check and let me know if I should change anything!
