### PR TITLE
Be ready for PHP 7.0!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,6 @@ matrix:
       env: SCRUTINIZER_REPORT=true
     - php: 7.0
 
-php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
-    env:
-  - 7.0
-
 before_script:
   - composer self-update
   - composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,24 @@
 language: php
 
+matrix:
+  include:
+    - php: 5.3
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+      env: SCRUTINIZER_REPORT=true
+    - php: 7.0
+
 php:
+  - 5.3
+  - 5.4
   - 5.5
+  - 5.6
+    env:
+  - 7.0
 
 before_script:
+  - composer self-update
   - composer install
   - phpenv rehash
 
@@ -11,6 +26,7 @@ script:
   - php vendor/bin/phpunit --coverage-clover=coverage.clover
   - php vendor/bin/phpcs -n --standard=PSR2 --ignore=vendor .
 
-after_script:
-  - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+after_script: >
+  [ "$SCRUTINIZER_REPORT" = true ]
+  && wget https://scrutinizer-ci.com/ocular.phar
+  && php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 
 matrix:
   include:
-    - php: 5.3
     - php: 5.4
     - php: 5.5
     - php: 5.6

--- a/composer.json
+++ b/composer.json
@@ -6,10 +6,10 @@
     "homepage": "http://github.com/particle-php/Filter",
     "license" : "BSD",
     "require": {
-        "php": ">=5.3.2"
+        "php": ">=5.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0",
+        "phpunit/phpunit": "^4.0",
         "squizlabs/php_codesniffer": "2.*",
         "mockery/mockery": "0.9.*"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.2"
+        "php": ">=5.4"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "fc2256911d26c0c8ebfba579c295546d",
+    "hash": "9c80a5a833ed10a61efd5bfcda61a4de",
     "packages": [],
     "packages-dev": [
         {
@@ -60,51 +60,6 @@
                 "instantiate"
             ],
             "time": "2014-10-13 12:58:55"
-        },
-        {
-            "name": "hamcrest/hamcrest-php",
-            "version": "v1.2.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/hamcrest/hamcrest-php.git",
-                "reference": "b37020aa976fa52d3de9aa904aa2522dc518f79c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/b37020aa976fa52d3de9aa904aa2522dc518f79c",
-                "reference": "b37020aa976fa52d3de9aa904aa2522dc518f79c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.2"
-            },
-            "replace": {
-                "cordoval/hamcrest-php": "*",
-                "davedevelopment/hamcrest-php": "*",
-                "kodova/hamcrest-php": "*"
-            },
-            "require-dev": {
-                "phpunit/php-file-iterator": "1.3.3",
-                "satooshi/php-coveralls": "dev-master"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "hamcrest"
-                ],
-                "files": [
-                    "hamcrest/Hamcrest.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD"
-            ],
-            "description": "This is the PHP port of Hamcrest Matchers",
-            "keywords": [
-                "test"
-            ],
-            "time": "2015-05-11 14:41:42"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -217,16 +172,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.0.16",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "934fd03eb6840508231a7f73eb8940cf32c3b66c"
+                "reference": "6b7d2094ca2a685a2cad846cb7cd7a30e8b9470f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/934fd03eb6840508231a7f73eb8940cf32c3b66c",
-                "reference": "934fd03eb6840508231a7f73eb8940cf32c3b66c",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/6b7d2094ca2a685a2cad846cb7cd7a30e8b9470f",
+                "reference": "6b7d2094ca2a685a2cad846cb7cd7a30e8b9470f",
                 "shasum": ""
             },
             "require": {
@@ -249,7 +204,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "2.1.x-dev"
                 }
             },
             "autoload": {
@@ -275,7 +230,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-04-11 04:35:00"
+            "time": "2015-06-01 07:35:26"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -535,16 +490,16 @@
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "2.3.1",
+            "version": "2.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "74ffb87f527f24616f72460e54b595f508dccb5c"
+                "reference": "253c005852591fd547fc18cd5b7b43a1ec82d8f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/74ffb87f527f24616f72460e54b595f508dccb5c",
-                "reference": "74ffb87f527f24616f72460e54b595f508dccb5c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/253c005852591fd547fc18cd5b7b43a1ec82d8f7",
+                "reference": "253c005852591fd547fc18cd5b7b43a1ec82d8f7",
                 "shasum": ""
             },
             "require": {
@@ -586,7 +541,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-04-02 05:36:41"
+            "time": "2015-05-29 05:19:18"
         },
         {
             "name": "sebastian/comparator",
@@ -1035,21 +990,20 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.6.7",
-            "target-dir": "Symfony/Component/Yaml",
+            "version": "v2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Yaml.git",
-                "reference": "f157ab074e453ecd4c0fa775f721f6e67a99d9e2"
+                "reference": "4a29a5248aed4fb45f626a7bbbd330291492f5c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Yaml/zipball/f157ab074e453ecd4c0fa775f721f6e67a99d9e2",
-                "reference": "f157ab074e453ecd4c0fa775f721f6e67a99d9e2",
+                "url": "https://api.github.com/repos/symfony/Yaml/zipball/4a29a5248aed4fb45f626a7bbbd330291492f5c3",
+                "reference": "4a29a5248aed4fb45f626a7bbbd330291492f5c3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=5.3.9"
             },
             "require-dev": {
                 "symfony/phpunit-bridge": "~2.7"
@@ -1057,11 +1011,11 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev"
+                    "dev-master": "2.7-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\Yaml\\": ""
                 }
             },
@@ -1081,7 +1035,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2015-05-02 15:18:45"
+            "time": "2015-05-02 15:21:08"
         }
     ],
     "aliases": [],
@@ -1090,7 +1044,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.3.2"
+        "php": ">=5.4"
     },
     "platform-dev": []
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "cc14c4b2234c8c090fd0987fab7a2041",
+    "hash": "993e7ebf3fd5d1e59c862ae143cd872e",
     "packages": [],
     "packages-dev": [
         {
@@ -282,16 +282,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.0.16",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "934fd03eb6840508231a7f73eb8940cf32c3b66c"
+                "reference": "6b7d2094ca2a685a2cad846cb7cd7a30e8b9470f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/934fd03eb6840508231a7f73eb8940cf32c3b66c",
-                "reference": "934fd03eb6840508231a7f73eb8940cf32c3b66c",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/6b7d2094ca2a685a2cad846cb7cd7a30e8b9470f",
+                "reference": "6b7d2094ca2a685a2cad846cb7cd7a30e8b9470f",
                 "shasum": ""
             },
             "require": {
@@ -314,7 +314,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "2.1.x-dev"
                 }
             },
             "autoload": {
@@ -340,7 +340,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-04-11 04:35:00"
+            "time": "2015-06-01 07:35:26"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -600,16 +600,16 @@
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "2.3.1",
+            "version": "2.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "74ffb87f527f24616f72460e54b595f508dccb5c"
+                "reference": "253c005852591fd547fc18cd5b7b43a1ec82d8f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/74ffb87f527f24616f72460e54b595f508dccb5c",
-                "reference": "74ffb87f527f24616f72460e54b595f508dccb5c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/253c005852591fd547fc18cd5b7b43a1ec82d8f7",
+                "reference": "253c005852591fd547fc18cd5b7b43a1ec82d8f7",
                 "shasum": ""
             },
             "require": {
@@ -651,7 +651,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-04-02 05:36:41"
+            "time": "2015-05-29 05:19:18"
         },
         {
             "name": "sebastian/comparator",
@@ -1100,21 +1100,20 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.6.7",
-            "target-dir": "Symfony/Component/Yaml",
+            "version": "v2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Yaml.git",
-                "reference": "f157ab074e453ecd4c0fa775f721f6e67a99d9e2"
+                "reference": "4a29a5248aed4fb45f626a7bbbd330291492f5c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Yaml/zipball/f157ab074e453ecd4c0fa775f721f6e67a99d9e2",
-                "reference": "f157ab074e453ecd4c0fa775f721f6e67a99d9e2",
+                "url": "https://api.github.com/repos/symfony/Yaml/zipball/4a29a5248aed4fb45f626a7bbbd330291492f5c3",
+                "reference": "4a29a5248aed4fb45f626a7bbbd330291492f5c3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=5.3.9"
             },
             "require-dev": {
                 "symfony/phpunit-bridge": "~2.7"
@@ -1122,11 +1121,11 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev"
+                    "dev-master": "2.7-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\Yaml\\": ""
                 }
             },
@@ -1146,7 +1145,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2015-05-02 15:18:45"
+            "time": "2015-05-02 15:21:08"
         }
     ],
     "aliases": [],
@@ -1155,7 +1154,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.3.2"
+        "php": ">=5.4"
     },
     "platform-dev": []
 }

--- a/src/FilterResource.php
+++ b/src/FilterResource.php
@@ -52,7 +52,7 @@ class FilterResource
      */
     public function bool()
     {
-        return $this->addRule(new FilterRule\Bool);
+        return $this->addRule(new FilterRule\Boolean);
     }
 
     /**
@@ -72,7 +72,7 @@ class FilterResource
      */
     public function float()
     {
-        return $this->addRule(new FilterRule\Float);
+        return $this->addRule(new FilterRule\CastFloat);
     }
 
     /**
@@ -82,7 +82,7 @@ class FilterResource
      */
     public function int()
     {
-        return $this->addRule(new FilterRule\Int);
+        return $this->addRule(new FilterRule\CastInt);
     }
 
     /**
@@ -137,7 +137,7 @@ class FilterResource
      */
     public function string()
     {
-        return $this->addRule(new FilterRule\String);
+        return $this->addRule(new FilterRule\CastString);
     }
 
     /**

--- a/src/FilterRule/Boolean.php
+++ b/src/FilterRule/Boolean.php
@@ -11,20 +11,20 @@ namespace Particle\Filter\FilterRule;
 use Particle\Filter\FilterRule;
 
 /**
- * Class Float
+ * Class Boolean
  *
  * @package Particle\Filter\FilterRule
  */
-class Float extends FilterRule
+class Boolean extends FilterRule
 {
     /**
-     * Convert the value to a float
+     * Convert the value to a bool
      *
      * @param mixed $value
-     * @return float
+     * @return string
      */
     public function filter($value)
     {
-        return floatval($value);
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
     }
 }

--- a/src/FilterRule/CastFloat.php
+++ b/src/FilterRule/CastFloat.php
@@ -11,20 +11,20 @@ namespace Particle\Filter\FilterRule;
 use Particle\Filter\FilterRule;
 
 /**
- * Class Int
+ * Class CastFloat
  *
  * @package Particle\Filter\FilterRule
  */
-class Int extends FilterRule
+class CastFloat extends FilterRule
 {
     /**
-     * Convert the value to an int
+     * Convert the value to a float
      *
      * @param mixed $value
-     * @return int
+     * @return float
      */
     public function filter($value)
     {
-        return intval($value);
+        return floatval($value);
     }
 }

--- a/src/FilterRule/CastInt.php
+++ b/src/FilterRule/CastInt.php
@@ -11,20 +11,20 @@ namespace Particle\Filter\FilterRule;
 use Particle\Filter\FilterRule;
 
 /**
- * Class Bool
+ * Class CastInt
  *
  * @package Particle\Filter\FilterRule
  */
-class Bool extends FilterRule
+class CastInt extends FilterRule
 {
     /**
-     * Convert the value to a bool
+     * Convert the value to an int
      *
      * @param mixed $value
-     * @return string
+     * @return int
      */
     public function filter($value)
     {
-        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+        return intval($value);
     }
 }

--- a/src/FilterRule/CastString.php
+++ b/src/FilterRule/CastString.php
@@ -11,11 +11,11 @@ namespace Particle\Filter\FilterRule;
 use Particle\Filter\FilterRule;
 
 /**
- * Class String
+ * Class CastString
  *
  * @package Particle\Filter\FilterRule
  */
-class String extends FilterRule
+class CastString extends FilterRule
 {
     /**
      * Convert the value to a string


### PR DESCRIPTION
Since PHP 7.0 is almost here and this lib is really new, why not be prepared to PHP 7?

I'm updating Travis to test 5.4 -> 7.0, 5.3 is excluded since the tests' dataprovider are using the new array notation, if we want to use PHP 5.3 the old php notation should be used!

In order to be compatible, was needed to change some classes names, like: Bool, String, Int, Float. Why?
https://wiki.php.net/rfc/reserve_more_types_in_php_7
http://php.net/manual/en/reserved.other-reserved-words.php

My proposal is to use the prefix Cast for those classes, minus Bool, which is now Boolean!
