### PR TITLE
Refactor Boolean to CastBool to keep consistent

### DIFF
--- a/src/FilterResource.php
+++ b/src/FilterResource.php
@@ -52,7 +52,7 @@ class FilterResource
      */
     public function bool()
     {
-        return $this->addRule(new FilterRule\Boolean);
+        return $this->addRule(new FilterRule\CastBool);
     }
 
     /**

--- a/src/FilterRule/CastBool.php
+++ b/src/FilterRule/CastBool.php
@@ -15,7 +15,7 @@ use Particle\Filter\FilterRule;
  *
  * @package Particle\Filter\FilterRule
  */
-class Boolean extends FilterRule
+class CastBool extends FilterRule
 {
     /**
      * Convert the value to a bool


### PR DESCRIPTION
### What

To support PHP 7, the filter-rule class `Bool` was renamed to `Boolean`, where other typecasting filters were renamed to `Cast...`. Here I'm renaming `Boolean` to `CastBool` to stay consistent in the codebase.
### How to test
1. See `Bool` is renamed to `CastBool`
2. See that all tests pass
