### PR TITLE
Fix: Chane vs. Change

### DIFF
--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -139,7 +139,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
     /**
      * Test if you can filter for multiple keys
      */
-    public function testNoChaneByDefault()
+    public function testNoChangeByDefault()
     {
         $result = $this->filter->filter([
             'first_name' => ' JOHN ',


### PR DESCRIPTION
This PR
- [x] fixes a small typo in a test method, where I assume `Chane` should have been `Change`
