### PR TITLE
Fix: Run tasks on Travis in appropriate sections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,13 @@ matrix:
       env: SCRUTINIZER_REPORT=true
     - php: 7.0
 
-before_script:
+before_install:
   - composer self-update
+
+install:
   - composer install
+
+before_script:
   - phpenv rehash
 
 script:


### PR DESCRIPTION
This PR
- [x] updates `composer` in `before_install` section
- [x] installs dependencies with `composer` in `install` section
- [x] refreshes path in `before_script` section
