### PR TITLE
Alnum and letters filter rules

### DIFF
--- a/docs/filter-rules.md
+++ b/docs/filter-rules.md
@@ -3,11 +3,13 @@
 Particle\Filter tries to provide you the most common filters. An overview is listed below. If you want to add custom
 filters, take a look at the callback filter-rule, or check out "Extending the Filter" in the menu.
 
+* [alnum](#alnum)
 * [append](#append)
 * [bool](#bool)
 * [callback](#callback)
 * [float](#float)
 * [int](#int)
+* [letters](#letters)
 * [lower](#lower)
 * [numbers](#numbers)
 * [prepend](#prepend)
@@ -19,6 +21,17 @@ filters, take a look at the callback filter-rule, or check out "Extending the Fi
 * [upper](#upper)
 * [upperFirst](#upperfirst)
 
+## Alnum
+
+Filters everything but alphabetic numeric characters out of the value
+
+```php
+$f = new Filter;
+$f->value('name')->alnum();
+$result = $f->filter(['name' => '1!23-abc?']);
+// array(1) { ["name"]=> string(6) "123abc"
+```
+
 ## Append
 
 Appends a value to the end of the provided value.
@@ -26,8 +39,8 @@ Appends a value to the end of the provided value.
 ```php
 $f = new Filter;
 $f->value('name')->append(' is your name.');
-$result = $f->filter(['name' => 'Rick']);
-// array(1) { ["name"]=> string(18) "Rick is your name."
+$result = $f->filter(['name' => 'John']);
+// array(1) { ["name"]=> string(18) "John is your name."
 ```
 
 ## Bool
@@ -51,8 +64,8 @@ $f = new Filter;
 $f->value('name')->callback(function($value) {
     return '<strong>' . $value . '</strong>';
 });
-$result = $f->filter(['name' => 'Rick']);
-// array(1) { ["name"]=> string(21) "<strong>Rick</strong>"
+$result = $f->filter(['name' => 'John']);
+// array(1) { ["name"]=> string(21) "<strong>John</strong>"
 ```
 
 ## Float
@@ -77,6 +90,17 @@ $result = $f->filter(['value' => '123.123']);
 // array(1) { ["value"]=> int(123) } 
 ```
 
+## Letters
+
+Filters everything but letters out of the value
+
+```php
+$f = new Filter;
+$f->value('name')->letters();
+$result = $f->filter(['name' => 'john99!']);
+// array(1) { ["name"]=> string(4) "john"
+```
+
 ## Lower
 
 Lowercase the full value.
@@ -84,8 +108,8 @@ Lowercase the full value.
 ```php
 $f = new Filter;
 $f->value('name')->lower();
-$result = $f->filter(['name' => 'RICK']);
-// array(1) { ["name"]=> string(4) "rick"
+$result = $f->filter(['name' => 'JOHN']);
+// array(1) { ["name"]=> string(4) "john"
 ```
 
 ## Numbers
@@ -106,8 +130,8 @@ Appends a value to the end of the provided value.
 ```php
 $f = new Filter;
 $f->value('name')->prepend('Hello ');
-$result = $f->filter(['name' => 'Rick']);
-// array(1) { ["name"]=> string(10) "Hello Rick"
+$result = $f->filter(['name' => 'John']);
+// array(1) { ["name"]=> string(10) "Hello John"
 ```
 
 ## RegexReplace
@@ -128,8 +152,8 @@ Replace a needle for a replacement in the value.
 ```php
 $f = new Filter;
 $f->value('value')->replace(' ', '-');
-$result = $f->filter(['name' => 'hello im rick']);
-// array(1) { ["name"]=> string(13) "hello-im-rick" }
+$result = $f->filter(['name' => 'hello im john']);
+// array(1) { ["name"]=> string(13) "hello-im-john" }
 ```
 
 ## String
@@ -150,8 +174,8 @@ Strip all tags from the value.
 ```php
 $f = new Filter;
 $f->value('name')->stripHtml();
-$result = $f->filter(['name' => '<p><strong>Rick</strong></p>']);
-// array(1) { ["name"]=> string(4) "Rick"
+$result = $f->filter(['name' => '<p><strong>John</strong></p>']);
+// array(1) { ["name"]=> string(4) "John"
 ```
 
 Exclude some tags:
@@ -159,8 +183,8 @@ Exclude some tags:
 ```php
 $f = new Filter;
 $f->value('name')->stripHtml('<strong>');
-$result = $f->filter(['name' => '<p><strong>Rick</strong></p>']);
-// array(1) { ["name"]=> string(21) "<strong>Rick</strong>"
+$result = $f->filter(['name' => '<p><strong>John</strong></p>']);
+// array(1) { ["name"]=> string(21) "<strong>John</strong>"
 ```
 
 ## Trim
@@ -170,8 +194,8 @@ Strip all 'white-space' characters from the beginning and end of the string.
 ```php
 $f = new Filter;
 $f->value('name')->trim();
-$result = $f->filter(['name' => ' Rick ']);
-// array(1) { ["name"]=> string(4) "Rick"
+$result = $f->filter(['name' => ' John ']);
+// array(1) { ["name"]=> string(4) "John"
 ```
 
 You can also provide the specific characters that you want to strip.
@@ -179,8 +203,8 @@ You can also provide the specific characters that you want to strip.
 ```php
 $f = new Filter;
 $f->value('name')->trim("\s");
-$result = $f->filter(['name' => ' Rick ']);
-// array(1) { ["name"]=> string(4) "Rick"
+$result = $f->filter(['name' => ' John ']);
+// array(1) { ["name"]=> string(4) "John"
 ```
 
 ## Upper
@@ -190,8 +214,8 @@ Uppercase the full value.
 ```php
 $f = new Filter;
 $f->value('name')->upper();
-$result = $f->filter(['name' => 'rick']);
-// array(1) { ["name"]=> string(4) "RICK"
+$result = $f->filter(['name' => 'john']);
+// array(1) { ["name"]=> string(4) "JOHN"
 ```
 
 ## UpperFirst
@@ -201,6 +225,6 @@ Uppercase the first character of the value.
 ```php
 $f = new Filter;
 $f->value('name')->upperFirst();
-$result = $f->filter(['name' => 'rick']);
-// array(1) { ["name"]=> string(4) "Rick"
+$result = $f->filter(['name' => 'john']);
+// array(1) { ["name"]=> string(4) "John"
 ```

--- a/src/FilterResource.php
+++ b/src/FilterResource.php
@@ -35,6 +35,16 @@ class FilterResource
     }
 
     /**
+     * Add the alphabetic numeric rule to the chain
+     *
+     * @return $this
+     */
+    public function alnum()
+    {
+        return $this->addRule(new FilterRule\Alnum);
+    }
+
+    /**
      * Add append filter-rule to the chain
      *
      * @param string $append
@@ -86,6 +96,16 @@ class FilterResource
     }
 
     /**
+     * Add the letters-rule to the chain
+     *
+     * @return $this
+     */
+    public function letters()
+    {
+        return $this->addRule(new FilterRule\Letters);
+    }
+
+    /**
      * Add lower filter-rule to the chain
      *
      * @return $this
@@ -93,6 +113,16 @@ class FilterResource
     public function lower()
     {
         return $this->addRule(new FilterRule\Lower);
+    }
+
+    /**
+     * Add the numbers-rule to the chain
+     *
+     * @return $this
+     */
+    public function numbers()
+    {
+        return $this->addRule(new FilterRule\Numbers);
     }
 
     /**
@@ -180,16 +210,6 @@ class FilterResource
     public function upperFirst()
     {
         return $this->addRule(new FilterRule\UpperFirst);
-    }
-    
-    /**
-     * Add the numbers-rule to the chain
-     *
-     * @return $this
-     */
-    public function numbers()
-    {
-        return $this->addRule(new FilterRule\Numbers);
     }
 
     /**

--- a/src/FilterRule/Alnum.php
+++ b/src/FilterRule/Alnum.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Particle.
+ *
+ * @link      http://github.com/particle-php for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Particle (http://particle-php.com)
+ * @license   https://github.com/particle-php/Filter/blob/master/LICENSE New BSD License
+ */
+namespace Particle\Filter\FilterRule;
+
+use Particle\Filter\FilterRule;
+
+/**
+ * Class AlNum
+ *
+ * @package Particle\Filter\FilterRule
+ */
+class AlNum extends FilterRule
+{
+    /**
+     * Only return alphabetic numeric characters
+     *
+     * @param mixed $value
+     * @return string
+     */
+    public function filter($value)
+    {
+        return preg_replace('/\W|_/', '', $value);
+    }
+}

--- a/src/FilterRule/Letters.php
+++ b/src/FilterRule/Letters.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Particle.
+ *
+ * @link      http://github.com/particle-php for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Particle (http://particle-php.com)
+ * @license   https://github.com/particle-php/Filter/blob/master/LICENSE New BSD License
+ */
+namespace Particle\Filter\FilterRule;
+
+use Particle\Filter\FilterRule;
+
+/**
+ * Class Letters
+ *
+ * @package Particle\Filter\FilterRule
+ */
+class Letters extends FilterRule
+{
+    /**
+     * Only return letters
+     *
+     * @param mixed $value
+     * @return string
+     */
+    public function filter($value)
+    {
+        return preg_replace('/[^\pL]/', '', $value);
+    }
+}

--- a/tests/FilterRule/AlnumTest.php
+++ b/tests/FilterRule/AlnumTest.php
@@ -1,0 +1,49 @@
+<?php
+namespace Particle\Tests\Filter\FilterRule;
+
+use Particle\Filter\Filter;
+
+class AlnumTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Filter
+     */
+    protected $filter;
+
+    /**
+     * Prepare the filter
+     */
+    public function setUp()
+    {
+        $this->filter = new Filter();
+    }
+
+    /**
+     * @dataProvider getAlnumResults
+     * @param string $value
+     * @param string $filteredValue
+     */
+    public function testAlnumFilterRule($value, $filteredValue)
+    {
+        $this->filter->value('test')->alnum();
+
+        $result = $this->filter->filter([
+            'test' => $value
+        ]);
+
+        $this->assertEquals($result['test'], $filteredValue);
+    }
+
+    /**
+     * @return array
+     */
+    public function getAlnumResults()
+    {
+        return [
+            ['', ''],
+            ['0123456789', '0123456789'],
+            ['onlylettersinhere', 'onlylettersinhere'],
+            ['0l!e#t$t.e-r+s9', '0letters9'],
+        ];
+    }
+}

--- a/tests/FilterRule/LettersTest.php
+++ b/tests/FilterRule/LettersTest.php
@@ -1,0 +1,48 @@
+<?php
+namespace Particle\Tests\Filter\FilterRule;
+
+use Particle\Filter\Filter;
+
+class LettersTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Filter
+     */
+    protected $filter;
+
+    /**
+     * Prepare the filter
+     */
+    public function setUp()
+    {
+        $this->filter = new Filter();
+    }
+
+    /**
+     * @dataProvider getLettersResults
+     * @param string $value
+     * @param string $filteredValue
+     */
+    public function testLettersFilterRule($value, $filteredValue)
+    {
+        $this->filter->value('test')->letters();
+
+        $result = $this->filter->filter([
+            'test' => $value
+        ]);
+
+        $this->assertEquals($result['test'], $filteredValue);
+    }
+
+    /**
+     * @return array
+     */
+    public function getLettersResults()
+    {
+        return [
+            ['', ''],
+            ['onlylettersinhere', 'onlylettersinhere'],
+            ['0l!e#t$t.e-r+s9', 'letters'],
+        ];
+    }
+}


### PR DESCRIPTION
### What

This PR adds the `letters()` and `alnum()` filter rules to the filter's default rules.
### How to test
1. See that the filter rules `letters()`  and `alnum()` are now available by default
2. See all tests pass with 100% coverage
3. See that the new rules are added to the documentation
### ToDo
- [x] Add the new filter-rules to the documentation
