### PR TITLE
Feature: Add Multibyte support

### DIFF
--- a/docs/filter-rules.md
+++ b/docs/filter-rules.md
@@ -7,6 +7,7 @@ filters, take a look at the callback filter-rule, or check out "Extending the Fi
 * [append](#append)
 * [bool](#bool)
 * [callback](#callback)
+* [encode](#encode)
 * [float](#float)
 * [int](#int)
 * [letters](#letters)
@@ -67,6 +68,20 @@ $f->value('name')->callback(function($value) {
 $result = $f->filter(['name' => 'John']);
 // array(1) { ["name"]=> string(21) "<strong>John</strong>"
 ```
+
+## Encode
+
+Makes sure that the given value is in a specific encoding format.
+
+```php
+$f = new Filter;
+$f->value('text')->encode('Base64', 'UTF-8');
+$result = $f->filter(['text' => 'hello']);
+// array(1) { ["text"]=> string(8) "aGVsbG8="
+```
+
+if `$f->setEncodingFormat()` is set, you don't need to provide any parameters as the value encoding format will
+be set to that.
 
 ## Float
 

--- a/docs/multibyte-encoding.md
+++ b/docs/multibyte-encoding.md
@@ -1,0 +1,35 @@
+# Multibyte encoding
+
+To make sure your values get filtered correctly, we have to use the multi-byte (`mb_`) functionality from PHP. With
+this feature comes the ability to set the encoding format on the filter.
+
+```php
+$filter = new Particle\Filter\Filter;
+
+$filter->setEncodingFormat('utf-8'); // or another format if you like
+```
+
+If you don't use the function above, the string adaptive functions from php will use the default value from your
+php.ini, which is most likely UTF-8.
+
+**Note:** Make sure that you set the encoding format on before you add any filter rules to the filter, otherwise the
+default encoding format will be used on the filter rules defined before that setEncodingFormat.
+
+### Converting values to a specific encoding format
+
+If you know data is coming in in a different encoding format than what you want to be working with, you can use the
+encode filter rule to convert the value.
+
+```php
+$filter->value('first_name')->encode('UTF-8')->upper();
+```
+
+### Using multibyte a regex
+
+If you want to use multi-byte encoded regex, the following php functions should be used:
+
+```php
+mb_regex_encoding('UTF-8');
+```
+
+These functions are not included in Particle\Filter as it might lead to unexpected behaviour.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,3 +6,4 @@ pages:
 - [basic-usage.md, Basic usage]
 - [filter-rules.md, Filter-rules]
 - [extending.md, Extending the Filter]
+- [multibyte-encoding.md, Multibyte encoding]

--- a/src/Chain.php
+++ b/src/Chain.php
@@ -40,10 +40,13 @@ class Chain
      * Add a new rule to the chain
      *
      * @param FilterRule $rule
+     * @param string|null $encodingFormat
      * @return $this
      */
-    public function addRule(FilterRule $rule)
+    public function addRule(FilterRule $rule, $encodingFormat)
     {
+        $rule->setEncodingFormat($encodingFormat);
+
         $this->rules[] = $rule;
 
         return $this;

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -28,6 +28,11 @@ class Filter
     protected $data = [];
 
     /**
+     * @var string|null
+     */
+    protected $encodingFormat = null;
+
+    /**
      * @var Chain
      */
     protected $globalChain = null;
@@ -81,6 +86,16 @@ class Filter
     }
 
     /**
+     * Set the encoding format for all string manipulating filter-rules
+     *
+     * @param $encodingFormat
+     */
+    public function setEncodingFormat($encodingFormat)
+    {
+        $this->encodingFormat = $encodingFormat;
+    }
+
+    /**
      * Set a filter rule on a chain
      *
      * @param FilterRule $rule
@@ -88,7 +103,7 @@ class Filter
      */
     public function addFilterRule(FilterRule $rule, $key = null)
     {
-        $this->getChain($key)->addRule($rule);
+        $this->getChain($key)->addRule($rule, $this->encodingFormat);
     }
 
     /**
@@ -121,7 +136,12 @@ class Filter
     {
         foreach ($this->chains as $key => $chain) {
             if ($this->data->has($key)) {
-                $this->data->set($key, $chain->filter($this->data->get($key)));
+                $this->data->set(
+                    $key,
+                    $chain->filter(
+                        $this->data->get($key)
+                    )
+                );
             }
         }
     }

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -18,14 +18,14 @@ use Particle\Filter\Value\Container;
 class Filter
 {
     /**
-     * @var Chain[]
+     * @var array<string, Chain>
      */
     protected $chains = [];
 
     /**
      * @var Container
      */
-    protected $data = [];
+    protected $data;
 
     /**
      * @var string|null
@@ -86,9 +86,11 @@ class Filter
     }
 
     /**
-     * Set the encoding format for all string manipulating filter-rules
+     * Set the encoding format for all string manipulating filter-rules.
+     * Note: You should set the encoding format before you add filter-rules to your filter, otherwise the
+     * encoding format would not be set on the values added before the encoding format was set.
      *
-     * @param $encodingFormat
+     * @param string $encodingFormat
      */
     public function setEncodingFormat($encodingFormat)
     {

--- a/src/FilterResource.php
+++ b/src/FilterResource.php
@@ -35,7 +35,7 @@ class FilterResource
     }
 
     /**
-     * Add the alphabetic numeric rule to the chain
+     * Results rule that returns alphabetic numeric characters from the value
      *
      * @return $this
      */
@@ -45,7 +45,7 @@ class FilterResource
     }
 
     /**
-     * Add append filter-rule to the chain
+     * Results rule that returns the value appended with a given value
      *
      * @param string $append
      * @return Chain
@@ -56,7 +56,7 @@ class FilterResource
     }
 
     /**
-     * Add bool filter-rule to the chain
+     * Results rule that returns a casted boolean
      *
      * @return $this
      */
@@ -66,8 +66,9 @@ class FilterResource
     }
 
     /**
-     * Add callback filter-rule to the chain
+     * Returns rule that returns a value modified by a callable closure
      *
+     * @param callable $callable
      * @return $this
      */
     public function callback(callable $callable)
@@ -76,7 +77,19 @@ class FilterResource
     }
 
     /**
-     * Add float filter-rule to the chain
+     * Returns rule that returns an value in a specific encoding format
+     *
+     * @param string|null $toEncodingFormat
+     * @param string|null $fromEncodingFormat
+     * @return FilterResource
+     */
+    public function encode($toEncodingFormat = null, $fromEncodingFormat = null)
+    {
+        return $this->addRule(new FilterRule\Encode($toEncodingFormat, $fromEncodingFormat));
+    }
+
+    /**
+     * Returns rule that results a casted float
      *
      * @return $this
      */
@@ -86,7 +99,7 @@ class FilterResource
     }
 
     /**
-     * Add int filter-rule to the chain
+     * Returns rule that results a casted int
      *
      * @return $this
      */
@@ -96,7 +109,7 @@ class FilterResource
     }
 
     /**
-     * Add the letters-rule to the chain
+     * Returns rule that results all letters of a value
      *
      * @return $this
      */
@@ -106,7 +119,7 @@ class FilterResource
     }
 
     /**
-     * Add lower filter-rule to the chain
+     * Returns rule that results a lower-cased value
      *
      * @return $this
      */
@@ -116,7 +129,7 @@ class FilterResource
     }
 
     /**
-     * Add the numbers-rule to the chain
+     * Returns rule that results all numbers of a value
      *
      * @return $this
      */
@@ -126,7 +139,7 @@ class FilterResource
     }
 
     /**
-     * Add prepend filter-rule to the chain
+     * Results rule that returns the value prepended with a given value
      *
      * @param string $prepend
      * @return Chain
@@ -137,7 +150,7 @@ class FilterResource
     }
 
     /**
-     * Add replace filter-rule to the chain
+     * Results rule that returns a value with replacements by a regex
      *
      * @param string $searchRegex
      * @param string $replace
@@ -149,7 +162,7 @@ class FilterResource
     }
 
     /**
-     * Add replace filter-rule to the chain
+     * Results rule that returns a value with replacements
      *
      * @param mixed $search
      * @param mixed $replace
@@ -161,7 +174,7 @@ class FilterResource
     }
 
     /**
-     * Add string filter-rule to the chain
+     * Returns rule that results a casted string
      *
      * @return $this
      */
@@ -171,7 +184,7 @@ class FilterResource
     }
 
     /**
-     * Add stripHtml filter-rule to the chain
+     * Results rule that results a html-stripped value
      *
      * @param null|string $excludeTags
      * @return $this
@@ -182,7 +195,7 @@ class FilterResource
     }
 
     /**
-     * Add trim filter-rule to the chain
+     * Returns rule that results a trimmed value
      *
      * @param string|null $characters
      * @return $this
@@ -193,7 +206,7 @@ class FilterResource
     }
 
     /**
-     * Add upper filter-rule to the chain
+     * Results rule that returns an upper-cased value
      *
      * @return $this
      */
@@ -203,7 +216,7 @@ class FilterResource
     }
 
     /**
-     * Add upper-first filter-rule to the chain
+     * Returns rule that results a value starting with a upper-cased character
      *
      * @return $this
      */

--- a/src/FilterRule.php
+++ b/src/FilterRule.php
@@ -14,6 +14,19 @@ namespace Particle\Filter;
 abstract class FilterRule
 {
     /**
+     * @var string|null
+     */
+    protected $encodingFormat;
+
+    /**
+     * @param string|null $encodingFormat
+     */
+    public function setEncodingFormat($encodingFormat)
+    {
+        $this->encodingFormat = $encodingFormat;
+    }
+
+    /**
      * @param mixed $value
      * @return mixed
      */

--- a/src/FilterRule/Encode.php
+++ b/src/FilterRule/Encode.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Particle.
+ *
+ * @link      http://github.com/particle-php for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Particle (http://particle-php.com)
+ * @license   https://github.com/particle-php/Filter/blob/master/LICENSE New BSD License
+ */
+namespace Particle\Filter\FilterRule;
+
+use Particle\Filter\FilterRule;
+
+/**
+ * Class Encode
+ *
+ * @package Particle\Filter\FilterRule
+ */
+class Encode extends FilterRule
+{
+    /**
+     * @var string
+     */
+    protected $toEncoding;
+
+    /**
+     * @var string|null
+     */
+    protected $fromEncoding;
+
+    /**
+     * @param string|null $toEncoding
+     * @param string|null $fromEncoding
+     */
+    public function __construct($toEncoding = null, $fromEncoding = null)
+    {
+        if ($toEncoding === null) {
+            $toEncoding = $this->encodingFormat;
+        }
+
+        $this->toEncoding = $toEncoding;
+        $this->fromEncoding = $fromEncoding;
+    }
+
+    /**
+     * Changes encoding of the value
+     *
+     * @param mixed $value
+     * @return string
+     */
+    public function filter($value)
+    {
+        if ($this->toEncoding === null) {
+            return $value;
+        }
+
+        if ($this->fromEncoding === null) {
+            return mb_convert_encoding($value, $this->toEncoding);
+        }
+
+        return mb_convert_encoding($value, $this->toEncoding, $this->fromEncoding);
+    }
+}

--- a/src/FilterRule/Lower.php
+++ b/src/FilterRule/Lower.php
@@ -25,6 +25,6 @@ class Lower extends FilterRule
      */
     public function filter($value)
     {
-        return strtolower($value);
+        return mb_strtolower($value);
     }
 }

--- a/src/FilterRule/Lower.php
+++ b/src/FilterRule/Lower.php
@@ -29,6 +29,6 @@ class Lower extends FilterRule
             return mb_strtolower($value, $this->encodingFormat);
         }
 
-        return strtolower($value);
+        return mb_strtolower($value);
     }
 }

--- a/src/FilterRule/Lower.php
+++ b/src/FilterRule/Lower.php
@@ -25,6 +25,10 @@ class Lower extends FilterRule
      */
     public function filter($value)
     {
-        return mb_strtolower($value);
+        if ($this->encodingFormat !== null) {
+            return mb_strtolower($value, $this->encodingFormat);
+        }
+
+        return strtolower($value);
     }
 }

--- a/src/FilterRule/Upper.php
+++ b/src/FilterRule/Upper.php
@@ -25,6 +25,10 @@ class Upper extends FilterRule
      */
     public function filter($value)
     {
-        return strtoupper($value);
+        if ($this->encodingFormat !== null) {
+            return mb_strtoupper($value, $this->encodingFormat);
+        }
+
+        return mb_strtoupper($value);
     }
 }

--- a/src/FilterRule/UpperFirst.php
+++ b/src/FilterRule/UpperFirst.php
@@ -25,6 +25,15 @@ class UpperFirst extends FilterRule
      */
     public function filter($value)
     {
-        return ucfirst($value);
+        if ($this->encodingFormat !== null) {
+            $valueLength = mb_strlen($value, $this->encodingFormat);
+            $firstChar = mb_substr($value, 0, 1, $this->encodingFormat);
+            $rest = mb_substr($value, 1, $valueLength - 1, $this->encodingFormat);
+            return mb_strtoupper($firstChar, $this->encodingFormat) . $rest;
+        }
+
+        $firstChar = mb_substr($value, 0, 1);
+        $rest = mb_substr($value, 1);
+        return mb_strtoupper($firstChar) . $rest;
     }
 }

--- a/src/FilterRule/UpperFirst.php
+++ b/src/FilterRule/UpperFirst.php
@@ -26,9 +26,8 @@ class UpperFirst extends FilterRule
     public function filter($value)
     {
         if ($this->encodingFormat !== null) {
-            $valueLength = mb_strlen($value, $this->encodingFormat);
             $firstChar = mb_substr($value, 0, 1, $this->encodingFormat);
-            $rest = mb_substr($value, 1, $valueLength - 1, $this->encodingFormat);
+            $rest = mb_substr($value, 1, null, $this->encodingFormat);
             return mb_strtoupper($firstChar, $this->encodingFormat) . $rest;
         }
 

--- a/tests/FilterRule/AlnumTest.php
+++ b/tests/FilterRule/AlnumTest.php
@@ -31,7 +31,7 @@ class AlnumTest extends \PHPUnit_Framework_TestCase
             'test' => $value
         ]);
 
-        $this->assertEquals($result['test'], $filteredValue);
+        $this->assertEquals($filteredValue, $result['test']);
     }
 
     /**

--- a/tests/FilterRule/AppendTest.php
+++ b/tests/FilterRule/AppendTest.php
@@ -32,7 +32,7 @@ class AppendTest extends \PHPUnit_Framework_TestCase
             'test' => $value
         ]);
 
-        $this->assertEquals($result['test'], $filteredValue);
+        $this->assertEquals($filteredValue, $result['test']);
     }
 
     /**

--- a/tests/FilterRule/BoolTest.php
+++ b/tests/FilterRule/BoolTest.php
@@ -31,7 +31,7 @@ class BoolTest extends \PHPUnit_Framework_TestCase
             'test' => $value
         ]);
 
-        $this->assertEquals($result['test'], $filteredValue);
+        $this->assertEquals($filteredValue, $result['test']);
     }
 
     /**

--- a/tests/FilterRule/CallbackTest.php
+++ b/tests/FilterRule/CallbackTest.php
@@ -32,7 +32,7 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
             'test' => $value
         ]);
 
-        $this->assertEquals($result['test'], $filteredValue);
+        $this->assertEquals($filteredValue, $result['test']);
     }
 
     /**

--- a/tests/FilterRule/EncodeTest.php
+++ b/tests/FilterRule/EncodeTest.php
@@ -3,7 +3,7 @@ namespace Particle\Tests\Filter\FilterRule;
 
 use Particle\Filter\Filter;
 
-class RegexReplaceTest extends \PHPUnit_Framework_TestCase
+class EncodeTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var Filter
@@ -21,13 +21,13 @@ class RegexReplaceTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider getRegexReplaceResults
      * @param string $value
-     * @param string $searchRegex
-     * @param string $replace
+     * @param string|null $toFormat
+     * @param string|null $fromFormat
      * @param string $filteredValue
      */
-    public function testRegexReplaceFilterRule($value, $searchRegex, $replace, $filteredValue)
+    public function testRegexReplaceFilterRule($value, $toFormat, $fromFormat, $filteredValue)
     {
-        $this->filter->value('test')->regexReplace($searchRegex, $replace);
+        $this->filter->value('test')->encode($toFormat, $fromFormat);
 
         $result = $this->filter->filter([
             'test' => $value
@@ -42,8 +42,11 @@ class RegexReplaceTest extends \PHPUnit_Framework_TestCase
     public function getRegexReplaceResults()
     {
         return [
-            ['!!!l!#o?*l&&', '/[^a-zA-Z0-9\-]/', '', 'lol'],
-            ['no spaces please', '/[\s]/', '-', 'no-spaces-please'],
+            ['', null, null, ''],
+            ['hello', 'UTF-8', null, 'hello'],
+            ['hello', 'Base64', null, 'aGVsbG8='],
+            ['hello', 'Base64', 'UTF-8', 'aGVsbG8='],
+            ['aGVsbG8=', 'UTF-8', 'Base64', 'hello'],
         ];
     }
 }

--- a/tests/FilterRule/FloatTest.php
+++ b/tests/FilterRule/FloatTest.php
@@ -31,7 +31,7 @@ class FloatTest extends \PHPUnit_Framework_TestCase
             'test' => $value
         ]);
 
-        $this->assertEquals($result['test'], $filteredValue);
+        $this->assertEquals($filteredValue, $result['test']);
     }
 
     /**

--- a/tests/FilterRule/IntTest.php
+++ b/tests/FilterRule/IntTest.php
@@ -31,7 +31,7 @@ class IntTest extends \PHPUnit_Framework_TestCase
             'test' => $value
         ]);
 
-        $this->assertEquals($result['test'], $filteredValue);
+        $this->assertEquals($filteredValue, $result['test']);
     }
 
     /**

--- a/tests/FilterRule/LettersTest.php
+++ b/tests/FilterRule/LettersTest.php
@@ -31,7 +31,7 @@ class LettersTest extends \PHPUnit_Framework_TestCase
             'test' => $value
         ]);
 
-        $this->assertEquals($result['test'], $filteredValue);
+        $this->assertEquals($filteredValue, $result['test']);
     }
 
     /**

--- a/tests/FilterRule/LowerTest.php
+++ b/tests/FilterRule/LowerTest.php
@@ -22,29 +22,13 @@ class LowerTest extends \PHPUnit_Framework_TestCase
      * @dataProvider getLowerResults
      * @param string $value
      * @param string $filteredValue
+     * @param string|null $encodingFormat
      */
-    public function testLowerFilterRule($value, $filteredValue)
+    public function testLowerFilterRule($value, $filteredValue, $encodingFormat)
     {
-        $this->filter->value('test')->lower();
-
-        $result = $this->filter->filter([
-            'test' => $value
-        ]);
-
-        $this->assertEquals($result['test'], $filteredValue);
-    }
-
-    /**
-     * @dataProvider getLowerResults
-     * @param string $value
-     * @param string $filteredValue
-     */
-    public function testLowerFilterRuleMultiByte($value, $filteredValue)
-    {
-        $value = mb_convert_encoding($value, 'utf-16', 'utf-8');
-        $filteredValue = mb_convert_encoding($filteredValue, 'utf-16', 'utf-8');
-
-        $this->filter->setEncodingFormat('utf-8');
+        if ($encodingFormat !== null) {
+            $this->filter->setEncodingFormat($encodingFormat);
+        }
 
         $this->filter->value('test')->lower();
 
@@ -61,11 +45,13 @@ class LowerTest extends \PHPUnit_Framework_TestCase
     public function getLowerResults()
     {
         return [
-            ['text is low', 'text is low'],
-            ['', ''],
-            ['LOL', 'lol'],
-            ['L0L', 'l0l'],
-            ['~!LoLz!~', '~!lolz!~'],
+            ['text is low', 'text is low', null],
+            ['', '', null],
+            ['LOL', 'lol', null],
+            ['L0L', 'l0l', null],
+            ['~!LoLz!~', '~!lolz!~', null],
+            ['CE GARÇON EST TOMBÉ', 'ce garçon est tombé', 'utf-8'],
+            ['Τάχιστη αλώπηξ βαφής ψημένη γη', 'τάχιστη αλώπηξ βαφής ψημένη γη', 'utf-8'],
         ];
     }
 }

--- a/tests/FilterRule/LowerTest.php
+++ b/tests/FilterRule/LowerTest.php
@@ -35,6 +35,27 @@ class LowerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider getLowerResults
+     * @param string $value
+     * @param string $filteredValue
+     */
+    public function testLowerFilterRuleMultiByte($value, $filteredValue)
+    {
+        $value = mb_convert_encoding($value, 'utf-16', 'utf-8');
+        $filteredValue = mb_convert_encoding($filteredValue, 'utf-16', 'utf-8');
+
+        $this->filter->setEncodingFormat('utf-8');
+
+        $this->filter->value('test')->lower();
+
+        $result = $this->filter->filter([
+            'test' => $value
+        ]);
+
+        $this->assertEquals($result['test'], $filteredValue);
+    }
+
+    /**
      * @return array
      */
     public function getLowerResults()

--- a/tests/FilterRule/LowerTest.php
+++ b/tests/FilterRule/LowerTest.php
@@ -36,7 +36,7 @@ class LowerTest extends \PHPUnit_Framework_TestCase
             'test' => $value
         ]);
 
-        $this->assertEquals($result['test'], $filteredValue);
+        $this->assertEquals($filteredValue, $result['test']);
     }
 
     /**

--- a/tests/FilterRule/NumbersTest.php
+++ b/tests/FilterRule/NumbersTest.php
@@ -31,7 +31,7 @@ class NumbersTest extends \PHPUnit_Framework_TestCase
             'test' => $value
         ]);
 
-        $this->assertEquals($result['test'], $filteredValue);
+        $this->assertEquals($filteredValue, $result['test']);
     }
 
     /**

--- a/tests/FilterRule/PrependTest.php
+++ b/tests/FilterRule/PrependTest.php
@@ -32,7 +32,7 @@ class PrependTest extends \PHPUnit_Framework_TestCase
             'test' => $value
         ]);
 
-        $this->assertEquals($result['test'], $filteredValue);
+        $this->assertEquals($filteredValue, $result['test']);
     }
 
     /**

--- a/tests/FilterRule/RegexReplaceTest.php
+++ b/tests/FilterRule/RegexReplaceTest.php
@@ -33,7 +33,7 @@ class RegexReplaceTest extends \PHPUnit_Framework_TestCase
             'test' => $value
         ]);
 
-        $this->assertEquals($result['test'], $filteredValue);
+        $this->assertEquals($filteredValue, $result['test']);
     }
 
     /**

--- a/tests/FilterRule/ReplaceTest.php
+++ b/tests/FilterRule/ReplaceTest.php
@@ -33,7 +33,7 @@ class ReplaceTest extends \PHPUnit_Framework_TestCase
             'test' => $value
         ]);
 
-        $this->assertEquals($result['test'], $filteredValue);
+        $this->assertEquals($filteredValue, $result['test']);
     }
 
     /**

--- a/tests/FilterRule/ReplaceTest.php
+++ b/tests/FilterRule/ReplaceTest.php
@@ -46,6 +46,7 @@ class ReplaceTest extends \PHPUnit_Framework_TestCase
             ['no spaces please', ' ', '-', 'no-spaces-please'],
             ['ror', 'r', 'l', 'lol'],
             ['no  spaces please', ['  ', ' '], '-', 'no-spaces-please'],
+            ['漢字はユニコード', 'は', 'Foo', '漢字Fooユニコード'],
         ];
     }
 }

--- a/tests/FilterRule/StringTest.php
+++ b/tests/FilterRule/StringTest.php
@@ -31,7 +31,7 @@ class StringTest extends \PHPUnit_Framework_TestCase
             'test' => $value
         ]);
 
-        $this->assertEquals($result['test'], $filteredValue);
+        $this->assertEquals($filteredValue, $result['test']);
     }
 
     /**

--- a/tests/FilterRule/StripHtmlTest.php
+++ b/tests/FilterRule/StripHtmlTest.php
@@ -32,7 +32,7 @@ class StripHtmlTest extends \PHPUnit_Framework_TestCase
             'test' => $value
         ]);
 
-        $this->assertEquals($result['test'], $filteredValue);
+        $this->assertEquals($filteredValue, $result['test']);
     }
 
     /**

--- a/tests/FilterRule/TrimTest.php
+++ b/tests/FilterRule/TrimTest.php
@@ -36,7 +36,7 @@ class TrimTest extends \PHPUnit_Framework_TestCase
             'test' => $value
         ]);
 
-        $this->assertEquals($result['test'], $filteredValue);
+        $this->assertEquals($filteredValue, $result['test']);
     }
 
     /**

--- a/tests/FilterRule/UpperFirstTest.php
+++ b/tests/FilterRule/UpperFirstTest.php
@@ -36,7 +36,7 @@ class UpperFirstTest extends \PHPUnit_Framework_TestCase
             'test' => $value
         ]);
 
-        $this->assertEquals($result['test'], $filteredValue);
+        $this->assertEquals($filteredValue, $result['test']);
     }
 
     /**

--- a/tests/FilterRule/UpperFirstTest.php
+++ b/tests/FilterRule/UpperFirstTest.php
@@ -22,9 +22,14 @@ class UpperFirstTest extends \PHPUnit_Framework_TestCase
      * @dataProvider getUpperFirstResults
      * @param string $value
      * @param string $filteredValue
+     * @param string|null $encodingFormat
      */
-    public function testUpperFirstFilterRule($value, $filteredValue)
+    public function testUpperFirstFilterRule($value, $filteredValue, $encodingFormat)
     {
+        if ($encodingFormat !== null) {
+            $this->filter->setEncodingFormat($encodingFormat);
+        }
+
         $this->filter->value('test')->upperFirst();
 
         $result = $this->filter->filter([
@@ -40,11 +45,12 @@ class UpperFirstTest extends \PHPUnit_Framework_TestCase
     public function getUpperFirstResults()
     {
         return [
-            ['text is low', 'Text is low'],
-            ['', ''],
-            ['lol', 'Lol'],
-            ['l0l', 'L0l'],
-            ['~!lolz!~', '~!lolz!~'],
+            ['', '', null],
+            ['text is low', 'Text is low', null],
+            ['l0l', 'L0l', null],
+            ['~!lolz!~', '~!lolz!~', null],
+            ['çon est tombé', 'Çon est tombé', 'utf-8'],
+            ['τάχιστη αλώπηξ βαφής ψημένη γη', 'Τάχιστη αλώπηξ βαφής ψημένη γη', 'utf-8'],
         ];
     }
 }

--- a/tests/FilterRule/UpperTest.php
+++ b/tests/FilterRule/UpperTest.php
@@ -22,9 +22,14 @@ class UpperTest extends \PHPUnit_Framework_TestCase
      * @dataProvider getUpperResults
      * @param string $value
      * @param string $filteredValue
+     * @param string|null $encodingFormat
      */
-    public function testUpperFilterRule($value, $filteredValue)
+    public function testUpperFilterRule($value, $filteredValue, $encodingFormat)
     {
+        if ($encodingFormat !== null) {
+            $this->filter->setEncodingFormat($encodingFormat);
+        }
+
         $this->filter->value('test')->upper();
 
         $result = $this->filter->filter([
@@ -40,11 +45,13 @@ class UpperTest extends \PHPUnit_Framework_TestCase
     public function getUpperResults()
     {
         return [
-            ['text is up', 'TEXT IS UP'],
-            ['', ''],
-            ['lol', 'LOL'],
-            ['l0l', 'L0L'],
-            ['~!LoLz!~', '~!LOLZ!~'],
+            ['text is up', 'TEXT IS UP', null],
+            ['', '', null],
+            ['lol', 'LOL', null],
+            ['l0l', 'L0L', null],
+            ['~!LoLz!~', '~!LOLZ!~', null],
+            ['ce garçon est tombé', 'CE GARÇON EST TOMBÉ', 'utf-8'],
+            ['τάχιστη αλώπηξ βαφής ψημένη γη', 'ΤΆΧΙΣΤΗ ΑΛΏΠΗΞ ΒΑΦΉΣ ΨΗΜΈΝΗ ΓΗ', 'utf-8'],
         ];
     }
 }

--- a/tests/FilterRule/UpperTest.php
+++ b/tests/FilterRule/UpperTest.php
@@ -45,9 +45,8 @@ class UpperTest extends \PHPUnit_Framework_TestCase
     public function getUpperResults()
     {
         return [
-            ['text is up', 'TEXT IS UP', null],
             ['', '', null],
-            ['lol', 'LOL', null],
+            ['text is up', 'TEXT IS UP', null],
             ['l0l', 'L0L', null],
             ['~!LoLz!~', '~!LOLZ!~', null],
             ['ce garçon est tombé', 'CE GARÇON EST TOMBÉ', 'utf-8'],

--- a/tests/FilterRule/UpperTest.php
+++ b/tests/FilterRule/UpperTest.php
@@ -36,7 +36,7 @@ class UpperTest extends \PHPUnit_Framework_TestCase
             'test' => $value
         ]);
 
-        $this->assertEquals($result['test'], $filteredValue);
+        $this->assertEquals($filteredValue, $result['test']);
     }
 
     /**


### PR DESCRIPTION
### What

This PR adds multi-byte support to the filter.
### How to test
1. See that you can set an encoding format on the filter
2. See that the encoding format is used on all string manipulating filter-rules
3. See that all tests pass, coverage remains 100%, and quality remains a 10
4. See that documentation is added on multi-byte encoding
### ToDo
- [x] Update filter-rule lower
- [x] ~~Update filter-rule regexReplace~~ mb_ereg_replace has different behaviour
- [x] ~~Update filter-rule replace~~ added test to prove that this works with str_replace
- [x] ~~Update filter-rule string~~ safe
- [x] ~~Update filter-rule stripHtml~~ safe
- [x] ~~Update filter-rule trim~~ safe
- [x] Update filter-rule upper
- [x] Update filter-rule upperFirst
- [x] Update filter-rule numbers
- [x] Update filter-rule letters
- [x] Update filter-rule alnum
- [x] Add encoding filter-rule
- [x] Add documentation on using the encoding format
