### PR TITLE
Fix: Remove empty constructor

### DIFF
--- a/src/Filter.php
+++ b/src/Filter.php
@@ -38,13 +38,6 @@ class Filter
     protected $globalChain = null;
 
     /**
-     * Construct the filter
-     */
-    public function __construct()
-    {
-    }
-
-    /**
      * Set a filter for a value on a specific key
      *
      * @param string $key


### PR DESCRIPTION
This PR
- [x] removes an empty constructor, as it's just not needed
