### PR TITLE
Introduce a default value filter rule

### DIFF
--- a/docs/filter-rules.md
+++ b/docs/filter-rules.md
@@ -3,26 +3,26 @@
 Particle\Filter tries to provide you the most common filters. An overview is listed below. If you want to add custom
 filters, take a look at the callback filter-rule, or check out "Extending the Filter" in the menu.
 
-* [alnum](#alnum)
-* [append](#append)
-* [bool](#bool)
-* [callback](#callback)
-* [defaults](#defaults)
-* [encode](#encode)
-* [float](#float)
-* [int](#int)
-* [letters](#letters)
-* [lower](#lower)
-* [numberFormat](numberformat)
-* [numbers](#numbers)
-* [prepend](#prepend)
-* [regexReplace](#regexreplace)
-* [replace](#replace)
-* [string](#string)
-* [stripHtml](#striphtml)
-* [trim](#trim)
-* [upper](#upper)
-* [upperFirst](#upperfirst)
+* [alnum](#alnum)()
+* [append](#append)($append)
+* [bool](#bool)()
+* [callback](#callback)($callable, $allowNotSet = false)
+* [defaults](#defaults)($defaultValue)
+* [encode](#encode)($toEncodingFormat = null, $fromEncodingFormat = null)
+* [float](#float)()
+* [int](#int)()
+* [letters](#letters)()
+* [lower](#lower)()
+* [numberFormat](numberformat)($decimals, $decimalPoint, $thousandSeparator)
+* [numbers](#numbers)()
+* [prepend](#prepend)($prepend)
+* [regexReplace](#regexreplace)($searchRegex, $replace)
+* [replace](#replace)($search, $replace)
+* [string](#string)()
+* [stripHtml](#striphtml)($excludeTags = null)
+* [trim](#trim)($characters = null)
+* [upper](#upper)()
+* [upperFirst](#upperfirst)()
 
 ## Alnum
 
@@ -32,7 +32,7 @@ Filters everything but alphabetic numeric characters out of the value
 $f = new Filter;
 $f->value('name')->alnum();
 $result = $f->filter(['name' => '1!23-abc?']);
-// array(1) { ["name"]=> string(6) "123abc"
+// array(1) { ["name"]=> string(6) "123abc" }
 ```
 
 ## Append
@@ -43,7 +43,7 @@ Appends a value to the end of the provided value.
 $f = new Filter;
 $f->value('name')->append(' is your name.');
 $result = $f->filter(['name' => 'John']);
-// array(1) { ["name"]=> string(18) "John is your name."
+// array(1) { ["name"]=> string(18) "John is your name." }
 ```
 
 ## Bool
@@ -55,7 +55,7 @@ for the expected outcome.
 $f = new Filter;
 $f->value('newsletter')->bool();
 $result = $f->filter(['newsletter' => 'yes']);
-// array(1) { ["newsletter"]=> bool(true)
+// array(1) { ["newsletter"]=> bool(true) }
 ```
 
 ## Callback
@@ -68,7 +68,19 @@ $f->value('name')->callback(function($value) {
     return '<strong>' . $value . '</strong>';
 });
 $result = $f->filter(['name' => 'John']);
-// array(1) { ["name"]=> string(21) "<strong>John</strong>"
+// array(1) { ["name"]=> string(21) "<strong>John</strong>" }
+```
+
+Callback can also be used if a value is not set in the filter data. Make sure you set the second parameter
+`$allowNotEmpty` to `true`, and you can always populate the value with a callback.
+
+```php
+$f = new Filter;
+$f->value('year')->callback(function() {
+    return date('Y');
+}, true);
+$result = $f->filter([]); // note that no year is set
+// array(1) { ["year"]=> string(4) "2016" }
 ```
 
 ## Defaults
@@ -79,7 +91,7 @@ When there is no data present for a given value key, you can default to a given 
 $f = new Filter;
 $f->value('name')->defaults('Annonymous');
 $result = $f->filter([]); // Note: no name is given
-// array(1) { ["name"]=> string(10) "Annonymous"
+// array(1) { ["name"]=> string(10) "Annonymous" }
 ```
 
 ## Encode
@@ -90,7 +102,7 @@ Makes sure that the given value is in a specific encoding format.
 $f = new Filter;
 $f->value('text')->encode('Base64', 'UTF-8');
 $result = $f->filter(['text' => 'hello']);
-// array(1) { ["text"]=> string(8) "aGVsbG8="
+// array(1) { ["text"]=> string(8) "aGVsbG8=" }
 ```
 
 if `$f->setEncodingFormat()` is set, you don't need to provide any parameters as the value encoding format will
@@ -126,7 +138,7 @@ Filters everything but letters out of the value
 $f = new Filter;
 $f->value('name')->letters();
 $result = $f->filter(['name' => 'john99!']);
-// array(1) { ["name"]=> string(4) "john"
+// array(1) { ["name"]=> string(4) "john" }
 ```
 
 ## Lower
@@ -137,7 +149,7 @@ Lowercase the full value.
 $f = new Filter;
 $f->value('name')->lower();
 $result = $f->filter(['name' => 'JOHN']);
-// array(1) { ["name"]=> string(4) "john"
+// array(1) { ["name"]=> string(4) "john" }
 ```
 
 ## NumberFormat
@@ -167,7 +179,7 @@ Filters everything but numbers out of the value
 $f = new Filter;
 $f->value('name')->numbers();
 $result = $f->filter(['name' => '1a2s3']);
-// array(1) { ["name"]=> string(3) "123"
+// array(1) { ["name"]=> string(3) "123" }
 ```
 
 ## Prepend
@@ -178,7 +190,7 @@ Appends a value to the end of the provided value.
 $f = new Filter;
 $f->value('name')->prepend('Hello ');
 $result = $f->filter(['name' => 'John']);
-// array(1) { ["name"]=> string(10) "Hello John"
+// array(1) { ["name"]=> string(10) "Hello John" }
 ```
 
 ## RegexReplace
@@ -222,7 +234,7 @@ Strip all tags from the value.
 $f = new Filter;
 $f->value('name')->stripHtml();
 $result = $f->filter(['name' => '<p><strong>John</strong></p>']);
-// array(1) { ["name"]=> string(4) "John"
+// array(1) { ["name"]=> string(4) "John" }
 ```
 
 Exclude some tags:
@@ -231,7 +243,7 @@ Exclude some tags:
 $f = new Filter;
 $f->value('name')->stripHtml('<strong>');
 $result = $f->filter(['name' => '<p><strong>John</strong></p>']);
-// array(1) { ["name"]=> string(21) "<strong>John</strong>"
+// array(1) { ["name"]=> string(21) "<strong>John</strong>" }
 ```
 
 ## Trim
@@ -242,7 +254,7 @@ Strip all 'white-space' characters from the beginning and end of the string.
 $f = new Filter;
 $f->value('name')->trim();
 $result = $f->filter(['name' => ' John ']);
-// array(1) { ["name"]=> string(4) "John"
+// array(1) { ["name"]=> string(4) "John" }
 ```
 
 You can also provide the specific characters that you want to strip.
@@ -251,7 +263,7 @@ You can also provide the specific characters that you want to strip.
 $f = new Filter;
 $f->value('name')->trim("\s");
 $result = $f->filter(['name' => ' John ']);
-// array(1) { ["name"]=> string(4) "John"
+// array(1) { ["name"]=> string(4) "John" }
 ```
 
 ## Upper
@@ -262,7 +274,7 @@ Uppercase the full value.
 $f = new Filter;
 $f->value('name')->upper();
 $result = $f->filter(['name' => 'john']);
-// array(1) { ["name"]=> string(4) "JOHN"
+// array(1) { ["name"]=> string(4) "JOHN" }
 ```
 
 ## UpperFirst
@@ -273,5 +285,5 @@ Uppercase the first character of the value.
 $f = new Filter;
 $f->value('name')->upperFirst();
 $result = $f->filter(['name' => 'john']);
-// array(1) { ["name"]=> string(4) "John"
+// array(1) { ["name"]=> string(4) "John" }
 ```

--- a/docs/filter-rules.md
+++ b/docs/filter-rules.md
@@ -7,6 +7,7 @@ filters, take a look at the callback filter-rule, or check out "Extending the Fi
 * [append](#append)
 * [bool](#bool)
 * [callback](#callback)
+* [defaults](#defaults)
 * [encode](#encode)
 * [float](#float)
 * [int](#int)
@@ -68,6 +69,17 @@ $f->value('name')->callback(function($value) {
 });
 $result = $f->filter(['name' => 'John']);
 // array(1) { ["name"]=> string(21) "<strong>John</strong>"
+```
+
+## Defaults
+
+When there is no data present for a given value key, you can default to a given value.
+
+```php
+$f = new Filter;
+$f->value('name')->defaults('Annonymous');
+$result = $f->filter([]); // Note: no name is given
+// array(1) { ["name"]=> string(10) "Annonymous"
 ```
 
 ## Encode

--- a/src/Chain.php
+++ b/src/Chain.php
@@ -31,7 +31,7 @@ class Chain
     {
         /** @var FilterRule $rule */
         foreach ($this->rules as $rule) {
-            if ($isSet || !$isSet && $rule->allowedNotSet()) {
+            if ($isSet || $rule->allowedNotSet()) {
                 $value = $rule->filter($value);
                 $isSet = true;
             }

--- a/src/Chain.php
+++ b/src/Chain.php
@@ -23,20 +23,21 @@ class Chain
     /**
      * Execute all filters in the chain
      *
-     * @param bool $isEmpty
+     * @param bool $isSet
      * @param mixed $value
      * @return FilterResult
      */
-    public function filter($isEmpty, $value = null)
+    public function filter($isSet, $value = null)
     {
         /** @var FilterRule $rule */
         foreach ($this->rules as $rule) {
-            if (!$isEmpty || $isEmpty && $rule->allowEmpty()) {
+            if ($isSet || !$isSet && $rule->allowedNotSet()) {
                 $value = $rule->filter($value);
+                $isSet = true;
             }
         }
 
-        return new FilterResult($value === null, $value);
+        return new FilterResult($isSet, $value);
     }
 
     /**

--- a/src/Chain.php
+++ b/src/Chain.php
@@ -23,17 +23,20 @@ class Chain
     /**
      * Execute all filters in the chain
      *
+     * @param bool $isEmpty
      * @param mixed $value
-     * @return mixed
+     * @return FilterResult
      */
-    public function filter($value)
+    public function filter($isEmpty, $value = null)
     {
         /** @var FilterRule $rule */
         foreach ($this->rules as $rule) {
-            $value = $rule->filter($value);
+            if (!$isEmpty || $isEmpty && $rule->allowEmpty()) {
+                $value = $rule->filter($value);
+            }
         }
 
-        return $value;
+        return new FilterResult($value === null, $value);
     }
 
     /**

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -134,7 +134,7 @@ class Filter
             if (is_array($value)) {
                 $data[$key] = $this->filterGlobals($value);
             } else {
-                $filterResult = $this->globalChain->filter(false, $value);
+                $filterResult = $this->globalChain->filter(true, $value);
                 $data[$key] = $filterResult->getFilteredValue();
             }
         }
@@ -152,10 +152,10 @@ class Filter
     protected function getFilterResult($key, Chain $chain)
     {
         if ($this->data->has($key)) {
-            return $chain->filter(false, $this->data->get($key));
+            return $chain->filter(true, $this->data->get($key));
         }
 
-        return $chain->filter(true);
+        return $chain->filter(false);
     }
 
     /**

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -102,6 +102,23 @@ class Filter
     }
 
     /**
+     * Filter the provided data
+     *
+     * @param array $data
+     * @return array
+     */
+    public function filter(array $data)
+    {
+        $data = $this->filterGlobals($data);
+
+        $this->data = new Container($data);
+
+        $this->filterChains();
+
+        return $this->data->getArrayCopy();
+    }
+
+    /**
      * Filter all set fields with a global chain, recursively
      *
      * @param array $data
@@ -117,11 +134,28 @@ class Filter
             if (is_array($value)) {
                 $data[$key] = $this->filterGlobals($value);
             } else {
-                $data[$key] = $this->globalChain->filter($value);
+                $filterResult = $this->globalChain->filter(false, $value);
+                $data[$key] = $filterResult->getFilteredValue();
             }
         }
 
         return $data;
+    }
+
+    /**
+     * Get the filter result from a chain
+     *
+     * @param string $key
+     * @param Chain $chain
+     * @return FilterResult
+     */
+    protected function getFilterResult($key, Chain $chain)
+    {
+        if ($this->data->has($key)) {
+            return $chain->filter(false, $this->data->get($key));
+        }
+
+        return $chain->filter(true);
     }
 
     /**
@@ -130,32 +164,14 @@ class Filter
     protected function filterChains()
     {
         foreach ($this->chains as $key => $chain) {
-            if ($this->data->has($key)) {
+            $filterResult = $this->getFilterResult($key, $chain);
+            if ($filterResult->isNotEmpty()) {
                 $this->data->set(
                     $key,
-                    $chain->filter(
-                        $this->data->get($key)
-                    )
+                    $filterResult->getFilteredValue()
                 );
             }
         }
-    }
-
-    /**
-     * Filter the provided data
-     *
-     * @param array $data
-     * @return array
-     */
-    public function filter(array $data)
-    {
-        $data = $this->filterGlobals($data);
-
-        $this->data = new Container($data);
-
-        $this->filterChains();
-
-        return $this->data->getArrayCopy();
     }
 
     /**

--- a/src/FilterResource.php
+++ b/src/FilterResource.php
@@ -77,6 +77,17 @@ class FilterResource
     }
 
     /**
+     * Returns rule that defaults a given value if the data key was not provided
+     *
+     * @param mixed $defaultValue
+     * @return $this
+     */
+    public function defaults($defaultValue)
+    {
+        return $this->addRule(new FilterRule\Defaults($defaultValue));
+    }
+
+    /**
      * Returns rule that returns an value in a specific encoding format
      *
      * @param string|null $toEncodingFormat

--- a/src/FilterResource.php
+++ b/src/FilterResource.php
@@ -69,11 +69,12 @@ class FilterResource
      * Returns rule that returns a value modified by a callable closure
      *
      * @param callable $callable
+     * @param bool $allowNotSet
      * @return $this
      */
-    public function callback(callable $callable)
+    public function callback(callable $callable, $allowNotSet = false)
     {
-        return $this->addRule(new FilterRule\Callback($callable));
+        return $this->addRule(new FilterRule\Callback($callable, $allowNotSet));
     }
 
     /**

--- a/src/FilterResource.php
+++ b/src/FilterResource.php
@@ -145,12 +145,12 @@ class FilterResource
      *
      * @param int $decimals
      * @param string $decimalPoint
-     * @param string $thousandSeperator
+     * @param string $thousandSeparator
      * @return $this
      */
-    public function numberFormat($decimals, $decimalPoint, $thousandSeperator)
+    public function numberFormat($decimals, $decimalPoint, $thousandSeparator)
     {
-        return $this->addRule(new FilterRule\NumberFormat($decimals, $decimalPoint, $thousandSeperator));
+        return $this->addRule(new FilterRule\NumberFormat($decimals, $decimalPoint, $thousandSeparator));
     }
 
     /**

--- a/src/FilterResult.php
+++ b/src/FilterResult.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Particle.
+ *
+ * @link      http://github.com/particle-php for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Particle (http://particle-php.com)
+ * @license   https://github.com/particle-php/Filter/blob/master/LICENSE New BSD License
+ */
+namespace Particle\Filter;
+
+/**
+ * @package Particle\Filter
+ */
+class FilterResult
+{
+    /**
+     * @var bool
+     */
+    protected $isEmpty;
+
+    /**
+     * @var mixed
+     */
+    protected $filteredValue;
+
+    /**
+     * @param bool $isEmpty
+     * @param null|mixed $filteredValue
+     */
+    public function __construct($isEmpty, $filteredValue = null)
+    {
+        $this->isEmpty = $isEmpty;
+        $this->filteredValue = $filteredValue;
+    }
+
+    /**
+     * Is the filter result not empty
+     *
+     * @return bool
+     */
+    public function isNotEmpty()
+    {
+        return !$this->isEmpty;
+    }
+
+    /**
+     * Get the filtered value
+     *
+     * @return mixed|null
+     */
+    public function getFilteredValue()
+    {
+        return $this->filteredValue;
+    }
+}

--- a/src/FilterResult.php
+++ b/src/FilterResult.php
@@ -16,7 +16,7 @@ class FilterResult
     /**
      * @var bool
      */
-    protected $isEmpty;
+    protected $isSet;
 
     /**
      * @var mixed
@@ -24,12 +24,12 @@ class FilterResult
     protected $filteredValue;
 
     /**
-     * @param bool $isEmpty
+     * @param bool $isSet
      * @param null|mixed $filteredValue
      */
-    public function __construct($isEmpty, $filteredValue = null)
+    public function __construct($isSet, $filteredValue = null)
     {
-        $this->isEmpty = $isEmpty;
+        $this->isSet = $isSet;
         $this->filteredValue = $filteredValue;
     }
 
@@ -40,7 +40,7 @@ class FilterResult
      */
     public function isNotEmpty()
     {
-        return !$this->isEmpty;
+        return $this->isSet;
     }
 
     /**

--- a/src/FilterRule.php
+++ b/src/FilterRule.php
@@ -21,7 +21,7 @@ abstract class FilterRule
     /**
      * @var bool
      */
-    protected $allowEmpty = false;
+    protected $allowNotSet = false;
 
     /**
      * @param string|null $encodingFormat
@@ -34,9 +34,9 @@ abstract class FilterRule
     /**
      * @return bool
      */
-    public function allowEmpty()
+    public function allowedNotSet()
     {
-        return $this->allowEmpty;
+        return $this->allowNotSet;
     }
 
     /**

--- a/src/FilterRule.php
+++ b/src/FilterRule.php
@@ -19,11 +19,24 @@ abstract class FilterRule
     protected $encodingFormat;
 
     /**
+     * @var bool
+     */
+    protected $allowEmpty = false;
+
+    /**
      * @param string|null $encodingFormat
      */
     public function setEncodingFormat($encodingFormat)
     {
         $this->encodingFormat = $encodingFormat;
+    }
+
+    /**
+     * @return bool
+     */
+    public function allowEmpty()
+    {
+        return $this->allowEmpty;
     }
 
     /**

--- a/src/FilterRule/Callback.php
+++ b/src/FilterRule/Callback.php
@@ -25,11 +25,13 @@ class Callback extends FilterRule
     /**
      * Set callable closure
      *
-     * @param $callable
+     * @param callable $callable
+     * @param bool $allowNotSet
      */
-    public function __construct($callable)
+    public function __construct(callable $callable, $allowNotSet = false)
     {
         $this->callable = $callable;
+        $this->allowNotSet = $allowNotSet;
     }
 
     /**

--- a/src/FilterRule/Defaults.php
+++ b/src/FilterRule/Defaults.php
@@ -22,7 +22,7 @@ class Defaults extends FilterRule
      *
      * @var bool
      */
-    protected $allowEmpty = true;
+    protected $allowNotSet = true;
 
     /**
      * @var mixed

--- a/src/FilterRule/Defaults.php
+++ b/src/FilterRule/Defaults.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Particle.
+ *
+ * @link      http://github.com/particle-php for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Particle (http://particle-php.com)
+ * @license   https://github.com/particle-php/Filter/blob/master/LICENSE New BSD License
+ */
+namespace Particle\Filter\FilterRule;
+
+use Particle\Filter\FilterRule;
+
+/**
+ * Class Defaults
+ *
+ * @package Particle\Filter\FilterRule
+ */
+class Defaults extends FilterRule
+{
+    /**
+     * Allows a default value to be set if no data key was provided
+     *
+     * @var bool
+     */
+    protected $allowEmpty = true;
+
+    /**
+     * @var mixed
+     */
+    protected $defaultValue;
+
+    /**
+     * @param mixed $defaultValue
+     */
+    public function __construct($defaultValue)
+    {
+        $this->defaultValue = $defaultValue;
+    }
+
+    /**
+     * Return a default value if no value was provided
+     *
+     * @param mixed $value
+     * @return string
+     */
+    public function filter($value)
+    {
+        return $value === null ? $this->defaultValue : $value;
+    }
+}

--- a/tests/FilterRule/CallbackTest.php
+++ b/tests/FilterRule/CallbackTest.php
@@ -41,7 +41,7 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
      */
     public function testAllowNotSetCallback()
     {
-        $this->filter->value('test')->callback(function() {
+        $this->filter->value('test')->callback(function () {
             $result = implode('.', range(1, 3));
             return $result;
         }, true);

--- a/tests/FilterRule/CallbackTest.php
+++ b/tests/FilterRule/CallbackTest.php
@@ -2,6 +2,7 @@
 namespace Particle\Tests\Filter\FilterRule;
 
 use Particle\Filter\Filter;
+use Particle\Filter\FilterRule;
 
 class CallbackTest extends \PHPUnit_Framework_TestCase
 {
@@ -36,6 +37,38 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test if setting allowNotSet to true still runs if no value was set
+     */
+    public function testAllowNotSetCallback()
+    {
+        $this->filter->value('test')->callback(function() {
+            $result = implode('.', range(1, 3));
+            return $result;
+        }, true);
+
+        $result = $this->filter->filter([]);
+
+        $this->assertEquals([
+            'test' => '1.2.3',
+        ], $result);
+    }
+
+    /**
+     * Test if the value was not randomly created if not specifically asked for
+     */
+    public function testNotSetWhenNotAllowedNotSet()
+    {
+        $this->filter->value('test')->callback(function() {
+            $result = implode('.', range(1, 3));
+            return $result;
+        });
+
+        $result = $this->filter->filter([]);
+
+        $this->assertEquals([], $result);
+    }
+
+    /**
      * @return array
      */
     public function getCallbackResults()
@@ -46,14 +79,14 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
                 function ($value) {
                     return 'l' . $value . 'l';
                 },
-                'lol'
+                'lol',
             ],
             [
                 99,
                 function ($value) {
                     return $value * 2;
                 },
-                198
+                198,
             ],
         ];
     }

--- a/tests/FilterRule/CallbackTest.php
+++ b/tests/FilterRule/CallbackTest.php
@@ -58,7 +58,7 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
      */
     public function testNotSetWhenNotAllowedNotSet()
     {
-        $this->filter->value('test')->callback(function() {
+        $this->filter->value('test')->callback(function () {
             $result = implode('.', range(1, 3));
             return $result;
         });

--- a/tests/FilterRule/DefaultsTest.php
+++ b/tests/FilterRule/DefaultsTest.php
@@ -59,6 +59,7 @@ class DefaultsTest extends \PHPUnit_Framework_TestCase
             [''],
             [0],
             ['John'],
+            [null],
             [1000],
             [true],
         ];

--- a/tests/FilterRule/DefaultsTest.php
+++ b/tests/FilterRule/DefaultsTest.php
@@ -1,0 +1,66 @@
+<?php
+namespace Particle\Tests\Filter\FilterRule;
+
+use Particle\Filter\Filter;
+
+class DefaultsTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Filter
+     */
+    protected $filter;
+
+    /**
+     * Prepare the filter
+     */
+    public function setUp()
+    {
+        $this->filter = new Filter();
+    }
+
+    /**
+     * @dataProvider getDefaultValues
+     * @param string $defaultValue
+     */
+    public function testValueDefaults($defaultValue)
+    {
+        $this->filter->value('test')->defaults($defaultValue);
+
+        $result = $this->filter->filter([]);
+
+        $this->assertSame([
+            'test' => $defaultValue,
+        ], $result);
+    }
+
+    /**
+     * @dataProvider getDefaultValues
+     * @param string $defaultValue
+     */
+    public function testDefaultIsIgnoredWhenValueIsSet($defaultValue)
+    {
+        $this->filter->value('test')->defaults($defaultValue);
+
+        $result = $this->filter->filter([
+            'test' => 'Doe'
+        ]);
+
+        $this->assertSame([
+            'test' => 'Doe',
+        ], $result);
+    }
+
+    /**
+     * @return array
+     */
+    public function getDefaultValues()
+    {
+        return [
+            [''],
+            [0],
+            ['John'],
+            [1000],
+            [true],
+        ];
+    }
+}

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -291,4 +291,16 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($expected, $result);
     }
+
+    /**
+     * Make sure that a default is set after multiple filter rules are set
+     */
+    public function testDefaultIsSetAfterOtherFilterRules()
+    {
+        $this->filter->value('test')->trim()->lower()->defaults('test');
+
+        $result = $this->filter->filter([]);
+
+        $this->assertEquals(['test' => 'test'], $result);
+    }
 }


### PR DESCRIPTION
### What

The filtering algorithm is edited so that filter rules can work with not set array keys, this allows the defaults filter rule to set a default value, in case nothing is provided.
### How to test
1. See in the tests that now a `->defaults()` filter rule is supported
2. See that you can now use `->callback($callable, $allowNotSet)`, where not set values could still be added by the filter using a callback.
3. See that all previous tests pass without any changes
4. See that proper documentation is added
5. See that scrutinizer's code grade is still a 10, and coverage 100%
### Small example

``` php
$f = new Filter;

$f->value('name')->defaults('Annonymous');

// Note: no name is given
$result = $f->filter([]);
// array(1) { ["name"]=> string(10) "Annonymous"
```
### Linked issue

https://github.com/particle-php/Filter/issues/34
