### PR TITLE
Make the filter data available in callbacks and custom filter rules

### DIFF
--- a/docs/filter-rules.md
+++ b/docs/filter-rules.md
@@ -62,9 +62,13 @@ $result = $f->filter(['newsletter' => 'yes']);
 
 Callback allows you to quickly add a custom filter, as you can provide a closure that manipulates the value.
 
+The callable function will receive two parameters from the callback rule. First `$value`, holding the
+currently filtered value for the current key. And second `$filterData`, holding all the data that is being
+filtered by the filter.
+
 ```php
 $f = new Filter;
-$f->value('name')->callback(function($value) {
+$f->value('name')->callback(function($value, $filterData) {
     return '<strong>' . $value . '</strong>';
 });
 $result = $f->filter(['name' => 'John']);
@@ -76,7 +80,7 @@ Callback can also be used if a value is not set in the filter data. Make sure yo
 
 ```php
 $f = new Filter;
-$f->value('year')->callback(function() {
+$f->value('year')->callback(function($value, $filterData) {
     return date('Y');
 }, true);
 $result = $f->filter([]); // note that no year is set

--- a/src/Chain.php
+++ b/src/Chain.php
@@ -25,12 +25,14 @@ class Chain
      *
      * @param bool $isSet
      * @param mixed $value
+     * @param array|null $filterData
      * @return FilterResult
      */
-    public function filter($isSet, $value = null)
+    public function filter($isSet, $value = null, $filterData = null)
     {
         /** @var FilterRule $rule */
         foreach ($this->rules as $rule) {
+            $rule->setFilterData($filterData);
             if ($isSet || $rule->allowedNotSet()) {
                 $value = $rule->filter($value);
                 $isSet = true;

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -134,7 +134,7 @@ class Filter
             if (is_array($value)) {
                 $data[$key] = $this->filterGlobals($value);
             } else {
-                $filterResult = $this->globalChain->filter(true, $value);
+                $filterResult = $this->globalChain->filter(true, $value, $data);
                 $data[$key] = $filterResult->getFilteredValue();
             }
         }
@@ -152,10 +152,10 @@ class Filter
     protected function getFilterResult($key, Chain $chain)
     {
         if ($this->data->has($key)) {
-            return $chain->filter(true, $this->data->get($key));
+            return $chain->filter(true, $this->data->get($key), $this->data->getArrayCopy());
         }
 
-        return $chain->filter(false);
+        return $chain->filter(false, null, $this->data->getArrayCopy());
     }
 
     /**

--- a/src/FilterRule.php
+++ b/src/FilterRule.php
@@ -24,11 +24,32 @@ abstract class FilterRule
     protected $allowNotSet = false;
 
     /**
+     * @var array|null
+     */
+    protected $filterData;
+
+    /**
      * @param string|null $encodingFormat
      */
     public function setEncodingFormat($encodingFormat)
     {
         $this->encodingFormat = $encodingFormat;
+    }
+
+    /**
+     * @param array|null $filterData
+     */
+    public function setFilterData($filterData)
+    {
+        $this->filterData = $filterData;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getFilterData()
+    {
+        return $this->filterData;
     }
 
     /**

--- a/src/FilterRule/Callback.php
+++ b/src/FilterRule/Callback.php
@@ -42,6 +42,6 @@ class Callback extends FilterRule
      */
     public function filter($value)
     {
-        return call_user_func($this->callable, $value);
+        return call_user_func($this->callable, $value, $this->getFilterData());
     }
 }

--- a/tests/FilterRule/CallbackTest.php
+++ b/tests/FilterRule/CallbackTest.php
@@ -82,9 +82,8 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->filter->filter($values);
 
-        $this->assertEquals([
-            'test' => $filteredValue,
-        ], $result);
+        $values['test'] = $filteredValue;
+        $this->assertEquals($values, $result);
     }
 
     /**

--- a/tests/FilterRule/CallbackTest.php
+++ b/tests/FilterRule/CallbackTest.php
@@ -69,6 +69,25 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test if the callback can build values using other data provided in the filter data
+     *
+     * @dataProvider getMultiValueCallbackResults
+     * @param array $values
+     * @param callable $callable
+     * @param mixed $filteredValue
+     */
+    public function testAccessFilterValuesInCallback($values, callable $callable, $filteredValue)
+    {
+        $this->filter->value('test')->callback($callable);
+
+        $result = $this->filter->filter($values);
+
+        $this->assertEquals([
+            'test' => $filteredValue,
+        ], $result);
+    }
+
+    /**
      * @return array
      */
     public function getCallbackResults()
@@ -87,6 +106,36 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
                     return $value * 2;
                 },
                 198,
+            ],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function getMultiValueCallbackResults()
+    {
+        return [
+            [
+                [
+                    'gender' => 'Sir',
+                    'test' => 'John',
+                    'last_name' => 'Doe',
+                ],
+                function ($value, $filterValues) {
+                    return implode(' ', [$filterValues['gender'], $value, $filterValues['last_name']]);
+                },
+                'Sir John Doe',
+            ],
+            [
+                [
+                    'multiplier' => 10,
+                    'test' => 50,
+                ],
+                function ($value, $filterValues) {
+                    return $value * $filterValues['multiplier'];
+                },
+                500,
             ],
         ];
     }


### PR DESCRIPTION
### What

The filtered data is now being pushed to filter rules, so that they could possibly do something with it. In case of the `->callback()` filter rule, a `$filterData` parameter will be provided to the callable.
### How to test
1. See in the tests that the callable off `->callback()` receives a second parameter including the filter data
2. See that all tests pass
3. See that proper documentation is updated
4. See that scrutinizer's code grade is still a 10, and coverage 100%
### Linked issue

https://github.com/particle-php/Filter/issues/36
