### PR TITLE
Support filtering repeated nested arrays with the each filter rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ var_dump($result);
 - Get a cleaned array after filtering
 - [A large set of available filters](http://filter.particle-php.com/en/latest/filter-rules/)
 - Ability to set default values if nothing is provided
+- Ability to filter nested, repeated arrays
 - Ability to extend the filter to add your own custom filter rules
 
 ## Non functional features

--- a/docs/filter-rules.md
+++ b/docs/filter-rules.md
@@ -98,6 +98,32 @@ $result = $f->filter([]); // Note: no name is given
 // array(1) { ["name"]=> string(10) "Annonymous" }
 ```
 
+## Each
+
+Filter nested repeated arrays, using a provided Filter instance in a closure.
+Note that the values in the array must be arrays too, else the filter can't apply a new filter on each element.
+
+```php
+$f = new Filter;
+$f->value('names')->each(function (Filter $filter) {
+    $filter->value('name')->upperFirst();
+});
+$result = $f->filter([
+    'names' => [
+        ['name' => 'john'],
+        ['name' => 'rick'],
+    ],
+]);
+/**
+ * array(1) {
+ *     ["names"]=> array(2) {
+ *         array(1) { ["name"]=> string(4) "John" }
+ *         array(1) { ["name"]=> string(4) "Rick" }
+ *     }
+ * }
+ */
+```
+
 ## Encode
 
 Makes sure that the given value is in a specific encoding format.
@@ -173,7 +199,7 @@ $result = $f->filter([
  *     ["discount"]=> string(4) "2.93"
  * } 
  */
- ```
+```
 
 ## Numbers
 

--- a/src/FilterResource.php
+++ b/src/FilterResource.php
@@ -89,11 +89,22 @@ class FilterResource
     }
 
     /**
+     * Returns rule that can filter repeated nested arrays
+     *
+     * @param callable $callable
+     * @return $this
+     */
+    public function each(callable $callable)
+    {
+        return $this->addRule(new FilterRule\Each($callable));
+    }
+
+    /**
      * Returns rule that returns an value in a specific encoding format
      *
      * @param string|null $toEncodingFormat
      * @param string|null $fromEncodingFormat
-     * @return FilterResource
+     * @return $this
      */
     public function encode($toEncodingFormat = null, $fromEncodingFormat = null)
     {

--- a/src/FilterRule/Each.php
+++ b/src/FilterRule/Each.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Particle.
+ *
+ * @link      http://github.com/particle-php for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Particle (http://particle-php.com)
+ * @license   https://github.com/particle-php/Filter/blob/master/LICENSE New BSD License
+ */
+namespace Particle\Filter\FilterRule;
+
+use Particle\Filter\Filter;
+use Particle\Filter\FilterRule;
+
+/**
+ * Class Each
+ *
+ * @package Particle\Filter\FilterRule
+ */
+class Each extends FilterRule
+{
+    /**
+     * @var callable
+     */
+    protected $callable;
+
+    /**
+     * @param callable $callable
+     */
+    public function __construct(callable $callable)
+    {
+        $this->callable = $callable;
+    }
+
+    /**
+     * When provided with an array, the callback filter will be executed for every value
+     *
+     * @param mixed $values
+     * @return array
+     */
+    public function filter($values)
+    {
+        if (!is_array($values)) {
+            return $values;
+        }
+
+        foreach ($values as $key => $value) {
+            $values[$key] = $this->filterValue($value);
+        }
+
+        return $values;
+    }
+
+    /**
+     * Filter a given value with a new filter instance in a callable
+     *
+     * @param $value
+     * @return array
+     */
+    protected function filterValue($value)
+    {
+        $filter = new Filter();
+
+        call_user_func($this->callable, $filter);
+
+        return $filter->filter($value);
+    }
+}

--- a/tests/FilterRule/EachTest.php
+++ b/tests/FilterRule/EachTest.php
@@ -1,0 +1,70 @@
+<?php
+namespace Particle\Tests\Filter\FilterRule;
+
+use Particle\Filter\Filter;
+
+class EachTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Filter
+     */
+    protected $filter;
+
+    /**
+     * Prepare the filter
+     */
+    public function setUp()
+    {
+        $this->filter = new Filter();
+    }
+
+    public function testBasicEach()
+    {
+        $this->filter->value('test')->each(function (Filter $filter) {
+            $filter->value('test')->upper();
+            $filter->value('test2')->lower();
+        });
+
+        $result = $this->filter->filter([
+            'test' => [
+                [
+                    'test' => 'lower',
+                    'test2' => 'UPPER'
+                ],
+                [
+                    'test' => 'john',
+                    'test2' => 'DOE',
+                ],
+            ],
+        ]);
+
+        $this->assertSame([
+            'test' => [
+                [
+                    'test' => 'LOWER',
+                    'test2' => 'upper'
+                ],
+                [
+                    'test' => 'JOHN',
+                    'test2' => 'doe',
+                ],
+            ],
+        ], $result);
+    }
+
+    public function testEachDoesNotDoAnythingWhenNotArray()
+    {
+        $this->filter->value('test')->each(function (Filter $filter) {
+            $filter->value('test')->upper();
+            $filter->value('test2')->lower();
+        });
+
+        $result = $this->filter->filter([
+            'test' => 'test',
+        ]);
+
+        $this->assertSame([
+            'test' => 'test',
+        ], $result);
+    }
+}


### PR DESCRIPTION
### What

Add support for filtering repeated nested arrays.
### How to test
1. See that you can now add filters for repeated, nested arrays using the each rule.
2. See that all tests pass
### ToDo
- [x] Update documentation
### Ticket
#39
