### PR TITLE
Fix: Class name does not match file name

### DIFF
--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -3,7 +3,7 @@ namespace Particle\Tests\Filter;
 
 use Particle\Filter\Filter;
 
-class ValidatorTest extends \PHPUnit_Framework_TestCase
+class FilterTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var Filter


### PR DESCRIPTION
This PR
- [x] fixes a class name that doesn't match the file name
