### PR TITLE
Fix: Simplify test bootstrapping

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,8 +9,11 @@
     processIsolation="false"
     stopOnFailure="false"
     syntaxCheck="false"
-    bootstrap="tests/bootstrap.php"
+    bootstrap="vendor/autoload.php"
 >
+    <php>
+        <ini name="date.timezone" value="UTC"/>
+    </php>
     <testsuites>
         <testsuite name="Particle Filter Test Suite">
             <directory suffix="Test.php">tests</directory>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,0 @@
-<?php
-date_default_timezone_set('UTC');
-
-// require the composer autoloader
-require_once __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
This PR
- [x] simplifies the test bootstrapping

💁 For reference, see 
- [PHP: Runtime Configuration](https://phpunit.de/manual/current/en/appendixes.configuration.html#appendixes.configuration.php-ini-constants-variables)
- [PHPUnit Manual: Setting PHP INI settings, Constants and Global Variables](http://php.net/manual/en/datetime.configuration.php#ini.date.timezone)
