### PR TITLE
Fix: Use consistent namespace schema for tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,10 @@
         "psr-4": {
             "Particle\\Filter\\": "src/"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Particle\\Filter\\Test\\": "tests/"
+        }
     }
 }

--- a/tests/FilterRule/AlNumTest.php
+++ b/tests/FilterRule/AlNumTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Filter\FilterRule;
+namespace Particle\Filter\Tests\FilterRule;
 
 use Particle\Filter\Filter;
 

--- a/tests/FilterRule/AppendTest.php
+++ b/tests/FilterRule/AppendTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Filter\FilterRule;
+namespace Particle\Filter\Tests\FilterRule;
 
 use Particle\Filter\Filter;
 

--- a/tests/FilterRule/BoolTest.php
+++ b/tests/FilterRule/BoolTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Filter\FilterRule;
+namespace Particle\Filter\Tests\FilterRule;
 
 use Particle\Filter\Filter;
 

--- a/tests/FilterRule/CallbackTest.php
+++ b/tests/FilterRule/CallbackTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Filter\FilterRule;
+namespace Particle\Filter\Tests\FilterRule;
 
 use Particle\Filter\Filter;
 use Particle\Filter\FilterRule;

--- a/tests/FilterRule/DefaultsTest.php
+++ b/tests/FilterRule/DefaultsTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Filter\FilterRule;
+namespace Particle\Filter\Tests\FilterRule;
 
 use Particle\Filter\Filter;
 

--- a/tests/FilterRule/EachTest.php
+++ b/tests/FilterRule/EachTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Filter\FilterRule;
+namespace Particle\Filter\Tests\FilterRule;
 
 use Particle\Filter\Filter;
 

--- a/tests/FilterRule/EncodeTest.php
+++ b/tests/FilterRule/EncodeTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Filter\FilterRule;
+namespace Particle\Filter\Tests\FilterRule;
 
 use Particle\Filter\Filter;
 

--- a/tests/FilterRule/FloatTest.php
+++ b/tests/FilterRule/FloatTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Filter\FilterRule;
+namespace Particle\Filter\Tests\FilterRule;
 
 use Particle\Filter\Filter;
 

--- a/tests/FilterRule/IntTest.php
+++ b/tests/FilterRule/IntTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Filter\FilterRule;
+namespace Particle\Filter\Tests\FilterRule;
 
 use Particle\Filter\Filter;
 

--- a/tests/FilterRule/LettersTest.php
+++ b/tests/FilterRule/LettersTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Filter\FilterRule;
+namespace Particle\Filter\Tests\FilterRule;
 
 use Particle\Filter\Filter;
 

--- a/tests/FilterRule/LowerTest.php
+++ b/tests/FilterRule/LowerTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Filter\FilterRule;
+namespace Particle\Filter\Tests\FilterRule;
 
 use Particle\Filter\Filter;
 

--- a/tests/FilterRule/NumberFormatTest.php
+++ b/tests/FilterRule/NumberFormatTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Filter\FilterRule;
+namespace Particle\Filter\Tests\FilterRule;
 
 use Particle\Filter\Filter;
 

--- a/tests/FilterRule/NumbersTest.php
+++ b/tests/FilterRule/NumbersTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Filter\FilterRule;
+namespace Particle\Filter\Tests\FilterRule;
 
 use Particle\Filter\Filter;
 

--- a/tests/FilterRule/PrependTest.php
+++ b/tests/FilterRule/PrependTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Filter\FilterRule;
+namespace Particle\Filter\Tests\FilterRule;
 
 use Particle\Filter\Filter;
 

--- a/tests/FilterRule/RegexReplaceTest.php
+++ b/tests/FilterRule/RegexReplaceTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Filter\FilterRule;
+namespace Particle\Filter\Tests\FilterRule;
 
 use Particle\Filter\Filter;
 

--- a/tests/FilterRule/RemoveNullTest.php
+++ b/tests/FilterRule/RemoveNullTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Filter\FilterRule;
+namespace Particle\Filter\Tests\FilterRule;
 
 use Particle\Filter\Filter;
 

--- a/tests/FilterRule/RemoveTest.php
+++ b/tests/FilterRule/RemoveTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Filter\FilterRule;
+namespace Particle\Filter\Tests\FilterRule;
 
 use Particle\Filter\Filter;
 

--- a/tests/FilterRule/ReplaceTest.php
+++ b/tests/FilterRule/ReplaceTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Filter\FilterRule;
+namespace Particle\Filter\Tests\FilterRule;
 
 use Particle\Filter\Filter;
 

--- a/tests/FilterRule/StringTest.php
+++ b/tests/FilterRule/StringTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Filter\FilterRule;
+namespace Particle\Filter\Tests\FilterRule;
 
 use Particle\Filter\Filter;
 

--- a/tests/FilterRule/StripHtmlTest.php
+++ b/tests/FilterRule/StripHtmlTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Filter\FilterRule;
+namespace Particle\Filter\Tests\FilterRule;
 
 use Particle\Filter\Filter;
 

--- a/tests/FilterRule/TrimTest.php
+++ b/tests/FilterRule/TrimTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Filter\FilterRule;
+namespace Particle\Filter\Tests\FilterRule;
 
 use Particle\Filter\Filter;
 

--- a/tests/FilterRule/UpperFirstTest.php
+++ b/tests/FilterRule/UpperFirstTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Filter\FilterRule;
+namespace Particle\Filter\Tests\FilterRule;
 
 use Particle\Filter\Filter;
 

--- a/tests/FilterRule/UpperTest.php
+++ b/tests/FilterRule/UpperTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Filter\FilterRule;
+namespace Particle\Filter\Tests\FilterRule;
 
 use Particle\Filter\Filter;
 

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Filter;
+namespace Particle\Filter\Tests;
 
 use Particle\Filter\Filter;
 


### PR DESCRIPTION
This PR
- [x] uses a namespace scheme for tests that is consistent with [`particle-php/Validator`](https://github.com/particle-php/Validator/blob/master/composer.json#L34-L38) and [`particle-php/State`](https://github.com/particle-php/State/blob/master/composer.json#L28-L32), and makes it explicit by referencing it in `composer.json`
