### PR TITLE
Disallow the usage of < and > in Slug rule

### DIFF
--- a/src/FilterRule/Slug.php
+++ b/src/FilterRule/Slug.php
@@ -60,7 +60,7 @@ class Slug extends FilterRule
 
         $value = transliterator_transliterate($this->transliterator, $value);
         $value = iconv("UTF-8", "ASCII//TRANSLIT//IGNORE", $value);
-        $value = preg_replace('/[-$?\s]+/', '-', $value);
+        $value = preg_replace('/[-$?\s<>]+/', '-', $value);
         $value = trim($value, '-');
         return strtolower($value);
     }

--- a/tests/FilterRule/SlugTest.php
+++ b/tests/FilterRule/SlugTest.php
@@ -44,6 +44,7 @@ class SlugTest extends \PHPUnit_Framework_TestCase
     {
         return [
             ['', '', '', ''],
+            ['Do not try this %27"--></style></script><script>alert("at home")</script>', 'do-not-try-this-27-style-script-script-alertat-home-script', '', ''],
             ['This is a great stuff to slug !', 'this-is-a-great-stuff-to-slug', '', ''],
             ['That too with somê spéciàl châractèr$ from €ope !', 'that-too-with-some-special-character-from-europe', '', ''],
             ['A æ Übérmensch på høyeste nivå! И я люблю PHP ! ﬁ', 'a-ae-ubermensch-pa-hoyeste-niva-i-a-lublu-php-fi', '', ''],


### PR DESCRIPTION
### What?

It appears that if we try to slug a string containing "<" or ">" characters they wouldn't be replaced by "-" which could be pretty disastrous if one is trying to XSS this value.

This is now solved.

### Checklist

- [x] Added unit test for added/fixed code
- [ ] Updated the documentation
- [x] Scrutinizer code coverage is 100%
- [x] Scrutinizer code quality is as high as possible

