### PR TITLE
Fix globalChain with number values

### DIFF
--- a/src/Filter.php
+++ b/src/Filter.php
@@ -134,7 +134,9 @@ class Filter
             $data = $this->filterValueWithGlobalChain($value, $key, $data);
         }
 
-        return array_filter($data);
+        return array_filter($data, function ($value) {
+            return $value || is_numeric($value);
+        });
     }
 
     /**

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -322,8 +322,18 @@ class FilterTest extends \PHPUnit_Framework_TestCase
                 ],
                 'test2' => null,
             ],
+            'test6' => '0',
+            'test7' => '0.0',
         ]);
 
-        $this->assertEquals(['test2' => 'test', 'test4' => 'test'], $result);
+        $this->assertEquals(
+            [
+                'test2' => 'test',
+                'test4' => 'test',
+                'test6' => '0',
+                'test7' => '0.0'
+            ],
+            $result
+        );
     }
 }


### PR DESCRIPTION
The function filterArrayWithGlobalChain use array_filter to remove all empty values.
By default array_filter remove number as 0 or 0.0. [PHP page](https://www.php.net/manual/en/language.types.boolean.php#language.types.boolean.casting)

I have a case that I need to pass 0 value, I know I could use `->defaults(0)`, but I think 0 should be a valid value.