### PR TITLE
Delete repeated code

### DIFF
--- a/src/FilterResource.php
+++ b/src/FilterResource.php
@@ -327,10 +327,6 @@ class FilterResource
      */
     protected function addRule(FilterRule $rule)
     {
-        if ($this->keys === null) {
-            $this->filter->addFilterRule($rule);
-        }
-
         if (is_array($this->keys)) {
             foreach ($this->keys as $key) {
                 $this->filter->addFilterRule($rule, $key);


### PR DESCRIPTION
When you use:
`$filter->all()->trim()`

globalChain have trim rule twice.

It's a bit difficult to create a test for this change...